### PR TITLE
[improve] if not exist default setting file, create one

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,17 +10,22 @@ It avoids external libraries (Win32 API + STL only) and focuses on safe operatio
 
 ## Quick start
 
-1. Copy `lastexecuterecord.sample.json` to `lastexecuterecord.json`
-2. Edit `exe` / `args` to match your commands
-3. Run `lastexecuterecord.exe`
+1. Run `lastexecuterecord.exe` (no arguments needed)
+2. The app creates a sample config at `%USERPROFILE%\.lastexecrecord\config.json`
+3. Edit the config file: set `enabled: true` and customize `exe` / `args` for your commands
+4. Run `lastexecuterecord.exe` again to execute your commands
 
-By default, the app reads **`<exe>.json`** (for example, `lastexecuterecord.json`).
+By default, the app reads **`%USERPROFILE%\.lastexecrecord\config.json`**.
+If this file doesn't exist, a minimal sample config is created automatically (with commands disabled by default for safety).
 
 ## Usage
 
-- `lastexecuterecord.exe --config <path>`: Specify the config JSON
+- `lastexecuterecord.exe`: Run with default config (auto-creates sample if missing)
+- `lastexecuterecord.exe --config <path>`: Specify a custom config JSON path
 - `lastexecuterecord.exe --dry-run`: Do not execute; only show decisions
 - `lastexecuterecord.exe --verbose`: Verbose logs (including skip reasons)
+
+All options can be combined, for example: `lastexecuterecord.exe --config myconfig.json --dry-run --verbose`
 
 ## Config schema (version 1)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,34 @@ If this file doesn't exist, a minimal sample config is created automatically (wi
 
 All options can be combined, for example: `lastexecuterecord.exe --config myconfig.json --dry-run --verbose`
 
+### Windows Terminal Profile Setup
+
+To register `lastexecuterecord.exe` as a Windows Terminal profile and continue running PowerShell or Command Prompt after execution, add the following profile to your Windows Terminal `settings.json`:
+
+```json
+{
+  "profiles": {
+    "list": [
+      {
+        "name": "lastexecrecord + PowerShell",
+        "commandline": "cmd.exe /c lastexecuterecord.exe && pwsh.exe",
+        "icon": "ms-appx:///ProfileIcons/PowerShell.png"
+      },
+      {
+        "name": "lastexecrecord + Command Prompt",
+        "commandline": "cmd.exe /c lastexecuterecord.exe && cmd.exe",
+        "icon": "ms-appx:///ProfileIcons/CommandPrompt.png"
+      }
+    ]
+  }
+}
+```
+
+- `&&` executes the next shell only if `lastexecuterecord.exe` exits successfully
+- Use `;` instead of `&&` if you want to continue regardless of exit code: `cmd.exe /c lastexecuterecord.exe ; pwsh.exe`
+
+To edit `settings.json`, open Windows Terminal and press `Ctrl + ,` or click the Settings icon.
+
 ## Config schema (version 1)
 
 Example: `lastexecuterecord.sample.json`
@@ -50,10 +78,37 @@ Example: `lastexecuterecord.sample.json`
 - `lastRunUtc` (string, optional): Example `2026-01-02T12:34:56Z` (seconds precision)
 - `lastExitCode` (number, optional): Previous exit code
 
+### sample(winget)
+
+```json
+{
+  "version": 1,
+  "defaults": {
+    "minIntervalSeconds": 64800,
+    "timeoutSeconds": 0
+  },
+  "commands": [
+    {
+      "name": "winget",
+      "enabled": true,
+      "exe": "c:\\windows\\system32\\sudo.exe",
+      "args": [
+        "winget",
+        "upgrade",
+        "--all",
+        "--accept-package-agreements",
+        "--silent"
+      ]
+    }
+  ]
+}
+```
+
 ## Notes (security)
 
 - The config uses `exe` + `args[]` and does not assume shell execution like `cmd.exe /c` (helps reduce injection risk).
 - To prevent concurrent runs, the program acquires an exclusive `<config>.lock` file.
+- **DO NOT** use environment variables or user input to construct `exe` or `args` in the config file, as this may lead to command injection vulnerabilities.
 
 ## Development
 


### PR DESCRIPTION
This pull request refactors the argument parsing logic in `src/lastexecuterecord/main.cpp` to improve usability when no command-line arguments are provided. Now, the program skips argument parsing if no arguments are given, rather than immediately showing usage and exiting. This makes the behavior more flexible and user-friendly.

Argument parsing improvements:
* Changed the logic to only parse command-line arguments if `argc > 1`, allowing the program to proceed without arguments instead of always printing usage and exiting. [[1]](diffhunk://#diff-2de70afdb9ff460347212c49b5766788ea11115dd90ba18bb02f491d8520828aL29-R30) [[2]](diffhunk://#diff-2de70afdb9ff460347212c49b5766788ea11115dd90ba18bb02f491d8520828aR58)