### PR TITLE
fix: detect network connection

### DIFF
--- a/src/.github/copilot-instructions.md
+++ b/src/.github/copilot-instructions.md
@@ -1,0 +1,4 @@
+﻿# Copilot Instructions
+
+## プロジェクト ガイドライン
+- All documents and code comments should be written in English for this repository.

--- a/src/lastexecuterecord.mstest/ConfigTests.cpp
+++ b/src/lastexecuterecord.mstest/ConfigTests.cpp
@@ -1,4 +1,4 @@
-#include "CppUnitTest.h"
+﻿#include "CppUnitTest.h"
 #include "Config.h"
 #include "FileUtil.h"
 #include <Windows.h>
@@ -316,6 +316,39 @@ namespace lastexecuterecordmstest
 
 			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
 			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Load_WithNetworkOptionInDefaults_ParsesCorrectly)
+		{
+			TempFile tmp(L"netoptdefaults.json");
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"defaults\": {\n"
+				L"    \"networkOption\": 0\n"
+				L"  },\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"}\n");
+
+			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
+			Assert::AreEqual(0, static_cast<int>(cfg.networkOption));
+		}
+
+		TEST_METHOD(Load_WithNetworkOptionInRootOverridesDefaults)
+		{
+			TempFile tmp(L"netoptoverride.json");
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"networkOption\": 1,\n"
+				L"  \"defaults\": {\n"
+				L"    \"networkOption\": 0\n"
+				L"  },\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"}\n");
+
+			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
+			Assert::AreEqual(1, static_cast<int>(cfg.networkOption));
 		}
 
 		TEST_METHOD(Load_WithInstallerWaitBehavior_Wait_ParsesCorrectly)

--- a/src/lastexecuterecord/Config.cpp
+++ b/src/lastexecuterecord/Config.cpp
@@ -134,13 +134,6 @@ AppConfig loadAndValidateConfig(const std::wstring& configPath) {
 
     cfg.version = getIntFieldOrDefault(cfg.root, L"version", 1);
 
-    // networkOption: 0=connected only, 1=metered ok, 2=always (default: 2)
-    std::int64_t netOpt = getIntFieldOrDefault(cfg.root, L"networkOption", 2);
-    if (netOpt < 0 || netOpt > 2) {
-        throw JsonParseError("networkOption must be 0, 1, or 2");
-    }
-    cfg.networkOption = static_cast<NetworkOption>(netOpt);
-
     // defaults
     const JsonValue* defaults = cfg.root.tryGet(L"defaults");
     if (defaults && defaults->isObject()) {
@@ -158,6 +151,22 @@ AppConfig loadAndValidateConfig(const std::wstring& configPath) {
             throw JsonParseError("defaults.installerMaxRetries must be >= 0");
         }
     }
+
+    // networkOption: 0=connected only, 1=metered ok, 2=always (default: 2)
+    // Check root level first, then fall back to defaults.networkOption
+    const JsonValue* rootNetOpt = cfg.root.tryGet(L"networkOption");
+    const JsonValue* defaultsNetOpt = (defaults && defaults->isObject()) ? defaults->tryGet(L"networkOption") : nullptr;
+    std::int64_t netOpt = 2; // AlwaysExecute
+    if (rootNetOpt && !rootNetOpt->isNull()) {
+        netOpt = rootNetOpt->asInt(L"networkOption");
+    }
+    else if (defaultsNetOpt && !defaultsNetOpt->isNull()) {
+        netOpt = defaultsNetOpt->asInt(L"defaults.networkOption");
+    }
+    if (netOpt < 0 || netOpt > 2) {
+        throw JsonParseError("networkOption must be 0, 1, or 2");
+    }
+    cfg.networkOption = static_cast<NetworkOption>(netOpt);
 
     const JsonValue& cmdsV = requireObjectField(cfg.root, L"commands", L"root");
     if (!cmdsV.isArray()) throw JsonParseError("commands must be array");

--- a/src/lastexecuterecord/NetworkUtil.cpp
+++ b/src/lastexecuterecord/NetworkUtil.cpp
@@ -1,4 +1,4 @@
-// NetworkUtil.cpp
+﻿// NetworkUtil.cpp
 #include "NetworkUtil.h"
 
 #include <Windows.h>
@@ -13,28 +13,30 @@ namespace ler {
 bool hasInternetConnection() {
     // Initialize COM for this thread if not already initialized
     HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-    bool comInitialized = (hrInit == S_OK);
-    
-    // Create NetworkListManager instance
-    ComPtr<INetworkListManager> pNetworkListManager;
-    HRESULT hr = CoCreateInstance(
-        CLSID_NetworkListManager,
-        nullptr,
-        CLSCTX_ALL,
-        IID_INetworkListManager,
-        reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
-    );
+    bool comInitialized = SUCCEEDED(hrInit);
     
     bool hasConnection = false;
-    if (SUCCEEDED(hr)) {
-        NLM_CONNECTIVITY connectivity;
-        hr = pNetworkListManager->GetConnectivity(&connectivity);
+    {
+        // Create NetworkListManager instance
+        ComPtr<INetworkListManager> pNetworkListManager;
+        HRESULT hr = CoCreateInstance(
+            CLSID_NetworkListManager,
+            nullptr,
+            CLSCTX_ALL,
+            IID_INetworkListManager,
+            reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
+        );
+
         if (SUCCEEDED(hr)) {
-            // Check if we have internet connectivity
-            hasConnection = (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
-                           (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+            NLM_CONNECTIVITY connectivity;
+            hr = pNetworkListManager->GetConnectivity(&connectivity);
+            if (SUCCEEDED(hr)) {
+                // Check if we have internet connectivity
+                hasConnection = (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
+                               (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+            }
         }
-    }
+    } // ComPtr released here, before CoUninitialize
     
     if (comInitialized) {
         CoUninitialize();
@@ -46,40 +48,42 @@ bool hasInternetConnection() {
 bool isConnectionMetered() {
     // Initialize COM for this thread if not already initialized
     HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-    bool comInitialized = (hrInit == S_OK);
-    
-    // Create NetworkListManager instance
-    ComPtr<INetworkListManager> pNetworkListManager;
-    HRESULT hr = CoCreateInstance(
-        CLSID_NetworkListManager,
-        nullptr,
-        CLSCTX_ALL,
-        IID_INetworkListManager,
-        reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
-    );
+    bool comInitialized = SUCCEEDED(hrInit);
     
     bool isMetered = false;
-    if (SUCCEEDED(hr)) {
-        // Use INetworkCostManager to check cost
-        ComPtr<INetworkCostManager> pCostManager;
-        hr = pNetworkListManager->QueryInterface(IID_INetworkCostManager,
-                                                 reinterpret_cast<void**>(pCostManager.GetAddressOf()));
-        
+    {
+        // Create NetworkListManager instance
+        ComPtr<INetworkListManager> pNetworkListManager;
+        HRESULT hr = CoCreateInstance(
+            CLSID_NetworkListManager,
+            nullptr,
+            CLSCTX_ALL,
+            IID_INetworkListManager,
+            reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
+        );
+
         if (SUCCEEDED(hr)) {
-            DWORD costFlags = 0;
-            hr = pCostManager->GetCost(&costFlags, nullptr);
-            
+            // Use INetworkCostManager to check cost
+            ComPtr<INetworkCostManager> pCostManager;
+            hr = pNetworkListManager->QueryInterface(IID_INetworkCostManager,
+                                                     reinterpret_cast<void**>(pCostManager.GetAddressOf()));
+
             if (SUCCEEDED(hr)) {
-                // Check if connection is NOT unrestricted (meaning it's metered)
-                isMetered = (costFlags != NLM_CONNECTION_COST_UNRESTRICTED);
+                DWORD costFlags = 0;
+                hr = pCostManager->GetCost(&costFlags, nullptr);
+
+                if (SUCCEEDED(hr)) {
+                    // Check if connection is NOT unrestricted (meaning it's metered)
+                    isMetered = (costFlags != NLM_CONNECTION_COST_UNRESTRICTED);
+                }
             }
         }
-    }
-    
+    } // ComPtr released here, before CoUninitialize
+
     if (comInitialized) {
         CoUninitialize();
     }
-    
+
     return isMetered;
 }
 
@@ -101,58 +105,60 @@ bool shouldExecuteBasedOnNetwork(NetworkOption option) {
             
             // Initialize COM for this thread if not already initialized
             HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-            bool comInitialized = (hrInit == S_OK);
-            
-            // Create NetworkListManager instance
-            ComPtr<INetworkListManager> pNetworkListManager;
-            HRESULT hr = CoCreateInstance(
-                CLSID_NetworkListManager,
-                nullptr,
-                CLSCTX_ALL,
-                IID_INetworkListManager,
-                reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
-            );
+            bool comInitialized = SUCCEEDED(hrInit);
             
             bool shouldExecute = false;
-            if (SUCCEEDED(hr)) {
-                // Check connectivity first
-                NLM_CONNECTIVITY connectivity;
-                hr = pNetworkListManager->GetConnectivity(&connectivity);
+            {
+                // Create NetworkListManager instance
+                ComPtr<INetworkListManager> pNetworkListManager;
+                HRESULT hr = CoCreateInstance(
+                    CLSID_NetworkListManager,
+                    nullptr,
+                    CLSCTX_ALL,
+                    IID_INetworkListManager,
+                    reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
+                );
+
                 if (SUCCEEDED(hr)) {
-                    bool hasConnection = (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
-                                        (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
-                    
-                    if (hasConnection) {
-                        // Connected - now check if metered using INetworkCostManager
-                        ComPtr<INetworkCostManager> pCostManager;
-                        hr = pNetworkListManager->QueryInterface(IID_INetworkCostManager, 
-                                                                 reinterpret_cast<void**>(pCostManager.GetAddressOf()));
-                        
-                        if (SUCCEEDED(hr)) {
-                            DWORD costFlags = 0;
-                            hr = pCostManager->GetCost(&costFlags, nullptr);
-                            
+                    // Check connectivity first
+                    NLM_CONNECTIVITY connectivity;
+                    hr = pNetworkListManager->GetConnectivity(&connectivity);
+                    if (SUCCEEDED(hr)) {
+                        bool hasConnection = (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
+                                            (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+
+                        if (hasConnection) {
+                            // Connected - now check if metered using INetworkCostManager
+                            ComPtr<INetworkCostManager> pCostManager;
+                            hr = pNetworkListManager->QueryInterface(IID_INetworkCostManager,
+                                                                     reinterpret_cast<void**>(pCostManager.GetAddressOf()));
+
                             if (SUCCEEDED(hr)) {
-                                // Execute only if NOT metered
-                                shouldExecute = (costFlags == NLM_CONNECTION_COST_UNRESTRICTED);
+                                DWORD costFlags = 0;
+                                hr = pCostManager->GetCost(&costFlags, nullptr);
+
+                                if (SUCCEEDED(hr)) {
+                                    // Execute only if NOT metered
+                                    shouldExecute = (costFlags == NLM_CONNECTION_COST_UNRESTRICTED);
+                                }
+                                else {
+                                    // If cost check fails, assume unrestricted for safety
+                                    shouldExecute = true;
+                                }
                             }
                             else {
-                                // If cost check fails, assume unrestricted for safety
+                                // If cost manager not available, assume unrestricted
                                 shouldExecute = true;
                             }
                         }
-                        else {
-                            // If cost manager not available, assume unrestricted
-                            shouldExecute = true;
-                        }
                     }
                 }
-            }
-            
+            } // ComPtr released here, before CoUninitialize
+
             if (comInitialized) {
                 CoUninitialize();
             }
-            
+
             return shouldExecute;
         }
             


### PR DESCRIPTION
This pull request improves the configuration handling and network utility logic, as well as adds new tests and documentation. The main focus is on making the `networkOption` configuration more flexible and robust, ensuring correct COM initialization, and improving code clarity and correctness.

**Configuration handling improvements:**

* Changed the logic for loading `networkOption` in `Config.cpp` to first check the root level, then fall back to `defaults.networkOption`, with a default value of 2 if not set. This ensures that the root value overrides the default, and adds validation for allowed values. [[1]](diffhunk://#diff-cdbf3d6c71562b6484d775573c66c4cac780414815611f897e70af60874b6ff6L137-L143) [[2]](diffhunk://#diff-cdbf3d6c71562b6484d775573c66c4cac780414815611f897e70af60874b6ff6R155-R170)

**Testing enhancements:**

* Added new tests in `ConfigTests.cpp` to verify that `networkOption` is correctly parsed from both the root and defaults sections, and that the root value takes precedence over the default.

**Network utility logic and code clarity:**

* Updated COM initialization checks in `NetworkUtil.cpp` to use `SUCCEEDED(hrInit)` instead of `hrInit == S_OK` for correctness, and moved smart pointer scope to ensure proper release before calling `CoUninitialize`. This change was applied to several functions: `hasInternetConnection`, `isConnectionMetered`, and `shouldExecuteBasedOnNetwork`. [[1]](diffhunk://#diff-b62c406c5585a3169eb4422fd9e1731e001c34f5b716266bf17393817ff5f65dL16-R19) [[2]](diffhunk://#diff-b62c406c5585a3169eb4422fd9e1731e001c34f5b716266bf17393817ff5f65dL49-R54) [[3]](diffhunk://#diff-b62c406c5585a3169eb4422fd9e1731e001c34f5b716266bf17393817ff5f65dL104-R111) [[4]](diffhunk://#diff-b62c406c5585a3169eb4422fd9e1731e001c34f5b716266bf17393817ff5f65dR156)

**Documentation:**

* Added a `copilot-instructions.md` file specifying that all documents and code comments should be written in English for this repository.

**Minor improvements:**

* Added UTF-8 BOMs to some source files for consistency. [[1]](diffhunk://#diff-784964bcba61e75f09a0dd57d69112051ef047f533e2c6524f3aedf6b1f48d67L1-R1) [[2]](diffhunk://#diff-b62c406c5585a3169eb4422fd9e1731e001c34f5b716266bf17393817ff5f65dL1-R1)