### PR TITLE
Harden design audit findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,17 @@
 
 version: 2
 updates:
-  - package-ecosystem: "vcpkg" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "vcpkg"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  - package-ecosystem: "vcpkg"
+    directory: "/src"
     schedule:
       interval: "weekly"

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,72 +5,112 @@ on:
     branches: [ main, develop ]
     paths:
       - 'src/**'
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+      - 'README.md'
+      - 'LICENSE'
   pull_request:
     branches: [ main, develop ]
     paths:
       - 'src/**'
+      - '.github/workflows/**'
+      - '.github/dependabot.yml'
+      - 'vcpkg.json'
+      - 'vcpkg-configuration.json'
+      - 'README.md'
+      - 'LICENSE'
+
+concurrency:
+  group: build-test-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build-and-test:
-    runs-on: windows-latest
-    
+  dependency-review:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
     permissions:
       contents: read
-    
+      pull-requests: read
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-      
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgGitCommitId: 'af752f21c9d79ba3df9cb0250ce2233933f58486'
-        
-    - name: Install dependencies
-      run: vcpkg install
+      - name: Dependency review
+        uses: actions/dependency-review-action@v4
 
-    - name: Build (Debug x64)
-      run: msbuild .\src\lastexecrecord.sln /m /p:Configuration=Debug /p:Platform=x64
+  build-and-test:
+    runs-on: windows-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
 
-    - name: Run tests (MSTest)
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Stop'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
 
-        $testDll = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\src" -Recurse -Filter "lastexecuterecord.mstest.dll" |
-          Select-Object -First 1
-        if (-not $testDll) {
-          throw "Test DLL not found: lastexecuterecord.mstest.dll"
-        }
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
 
-        $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
-        if (-not (Test-Path $vswhere)) {
-          throw "vswhere.exe not found at $vswhere"
-        }
+      - name: Build (Debug x64)
+        run: |
+          msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Debug /p:Platform=x64
+          msbuild .\src\lastexecuterecord.mstest\lastexecuterecord.mstest.vcxproj /m:1 /nr:false /p:Configuration=Debug /p:Platform=x64
 
-        $vsInstallPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.PackageGroup.TestTools.Core -property installationPath
-        if (-not $vsInstallPath) {
-          $vsInstallPath = & $vswhere -latest -products * -property installationPath
-        }
-        if (-not $vsInstallPath) {
-          throw "Visual Studio installation not found (vswhere returned empty)."
-        }
+      - name: Run tests (MSTest)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
 
-        $vstestCandidates = @(
-          (Join-Path $vsInstallPath "Common7\IDE\Extensions\TestPlatform\vstest.console.exe"),
-          (Join-Path $vsInstallPath "Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe")
-        ) | Where-Object { Test-Path $_ }
+          $testDll = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\src" -Recurse -Filter "lastexecuterecord.mstest.dll" |
+            Where-Object { $_.FullName -match "\\x64\\Debug\\" } |
+            Select-Object -First 1
+          if (-not $testDll) {
+            throw "Test DLL not found: lastexecuterecord.mstest.dll"
+          }
 
-        if ($vstestCandidates.Count -eq 0) {
-          throw "vstest.console.exe not found under: $vsInstallPath"
-        }
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          if (-not (Test-Path $vswhere)) {
+            throw "vswhere.exe not found at $vswhere"
+          }
 
-        $vstest = $vstestCandidates[0]
-        & $vstest $testDll.FullName /Platform:x64 /InIsolation /Logger:trx
+          $vsInstallPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.PackageGroup.TestTools.Core -property installationPath
+          if (-not $vsInstallPath) {
+            $vsInstallPath = & $vswhere -latest -products * -property installationPath
+          }
+          if (-not $vsInstallPath) {
+            throw "Visual Studio installation not found (vswhere returned empty)."
+          }
 
-    - name: Build (Release x64)
-      run: msbuild .\src\lastexecrecord.sln /m /p:Configuration=Release /p:Platform=x64
+          $vstestCandidates = @(
+            (Join-Path $vsInstallPath "Common7\IDE\Extensions\TestPlatform\vstest.console.exe"),
+            (Join-Path $vsInstallPath "Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe")
+          ) | Where-Object { Test-Path $_ }
 
+          if ($vstestCandidates.Count -eq 0) {
+            throw "vstest.console.exe not found under: $vsInstallPath"
+          }
+
+          $resultsDir = Join-Path $env:GITHUB_WORKSPACE "TestResults"
+          New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+          & $vstestCandidates[0] $testDll.FullName /Platform:x64 /InIsolation /ResultsDirectory:$resultsDir /Logger:trx
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: mstest-results
+          path: TestResults/**/*.trx
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Build (Release x64)
+        run: msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Release /p:Platform=x64
+
+      - name: Build (Release ARM64)
+        run: msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Release /p:Platform=ARM64

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,47 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - '.github/workflows/codeql.yml'
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - 'src/**'
+      - '.github/workflows/codeql.yml'
+  schedule:
+    - cron: '30 3 * * 1'
+
+concurrency:
+  group: codeql-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: c-cpp
+
+      - name: Build (Release x64)
+        run: msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Release /p:Platform=x64
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,103 +3,179 @@ name: Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
-  release:
+  build-package:
     runs-on: windows-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
 
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Setup MSBuild
+        uses: microsoft/setup-msbuild@v2
+
+      - name: Determine version
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $tag = '${{ github.ref_name }}'
+          if ($tag -notmatch '^v\d+\.\d+\.\d+$') {
+            throw "Release tag must use SemVer format vMAJOR.MINOR.PATCH (tag: '$tag')"
+          }
+
+          $version = $tag.Substring(1)
+          "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Build tests (Debug x64)
+        run: |
+          msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Debug /p:Platform=x64
+          msbuild .\src\lastexecuterecord.mstest\lastexecuterecord.mstest.vcxproj /m:1 /nr:false /p:Configuration=Debug /p:Platform=x64
+
+      - name: Run tests (MSTest)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $testDll = Get-ChildItem -Path "$env:GITHUB_WORKSPACE\src" -Recurse -Filter "lastexecuterecord.mstest.dll" |
+            Where-Object { $_.FullName -match "\\x64\\Debug\\" } |
+            Select-Object -First 1
+          if (-not $testDll) {
+            throw "Test DLL not found: lastexecuterecord.mstest.dll"
+          }
+
+          $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+          $vsInstallPath = & $vswhere -latest -products * -requires Microsoft.VisualStudio.PackageGroup.TestTools.Core -property installationPath
+          if (-not $vsInstallPath) {
+            $vsInstallPath = & $vswhere -latest -products * -property installationPath
+          }
+          if (-not $vsInstallPath) {
+            throw "Visual Studio installation not found (vswhere returned empty)."
+          }
+
+          $vstestCandidates = @(
+            (Join-Path $vsInstallPath "Common7\IDE\Extensions\TestPlatform\vstest.console.exe"),
+            (Join-Path $vsInstallPath "Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe")
+          ) | Where-Object { Test-Path $_ }
+
+          if ($vstestCandidates.Count -eq 0) {
+            throw "vstest.console.exe not found under: $vsInstallPath"
+          }
+
+          $resultsDir = Join-Path $env:GITHUB_WORKSPACE "TestResults"
+          New-Item -ItemType Directory -Force -Path $resultsDir | Out-Null
+          & $vstestCandidates[0] $testDll.FullName /Platform:x64 /InIsolation /ResultsDirectory:$resultsDir /Logger:trx
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-mstest-results
+          path: TestResults/**/*.trx
+          if-no-files-found: ignore
+          retention-days: 14
+
+      - name: Build (Release x64)
+        run: msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Release /p:Platform=x64
+
+      - name: Build (Release ARM64)
+        run: msbuild .\src\lastexecuterecord\lastexecuterecord.vcxproj /m:1 /nr:false /p:Configuration=Release /p:Platform=ARM64
+
+      - name: Package (zip)
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+
+          $workspace = $env:GITHUB_WORKSPACE
+          $dist = Join-Path $workspace 'dist'
+          New-Item -ItemType Directory -Force -Path $dist | Out-Null
+
+          $readmePath = Join-Path $workspace 'README.md'
+          $licensePath = Join-Path $workspace 'LICENSE'
+          if (-not (Test-Path $readmePath)) {
+            throw "README.md not found at $readmePath"
+          }
+          if (-not (Test-Path $licensePath)) {
+            throw "LICENSE not found at $licensePath"
+          }
+
+          function New-PackageZip {
+            param(
+              [Parameter(Mandatory=$true)][string]$arch,
+              [Parameter(Mandatory=$true)][string]$platformFolder
+            )
+
+            $exe = Get-ChildItem -Path (Join-Path $workspace 'src') -Recurse -Filter 'lastexecuterecord.exe' |
+              Where-Object { $_.FullName -match "\\$platformFolder\\Release\\" } |
+              Select-Object -First 1
+
+            if (-not $exe) {
+              throw "Executable not found for $arch (expected under src\\$platformFolder\\Release\\): lastexecuterecord.exe"
+            }
+
+            $stageDir = Join-Path $dist $arch
+            if (Test-Path $stageDir) {
+              Remove-Item -Recurse -Force $stageDir
+            }
+            New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
+
+            Copy-Item -Path $exe.FullName -Destination (Join-Path $stageDir $exe.Name) -Force
+            Copy-Item -Path $readmePath -Destination (Join-Path $stageDir 'README.md') -Force
+            Copy-Item -Path $licensePath -Destination (Join-Path $stageDir 'LICENSE') -Force
+
+            $zipName = "lastexec_${env:VERSION}_${arch}.zip"
+            $zipPath = Join-Path $dist $zipName
+            if (Test-Path $zipPath) {
+              Remove-Item -Force $zipPath
+            }
+
+            Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $zipPath
+          }
+
+          New-PackageZip -arch 'x64' -platformFolder 'x64'
+          New-PackageZip -arch 'arm64' -platformFolder 'ARM64'
+
+          $checksums = Get-ChildItem -Path $dist -Filter '*.zip' |
+            Sort-Object Name |
+            ForEach-Object {
+              $hash = Get-FileHash -Algorithm SHA256 -Path $_.FullName
+              "$($hash.Hash.ToLowerInvariant())  $($_.Name)"
+            }
+          $checksums | Set-Content -Path (Join-Path $dist 'SHA256SUMS.txt') -Encoding ascii
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-dist
+          path: dist/*
+          retention-days: 7
+
+  publish-release:
+    runs-on: ubuntu-latest
+    needs: build-package
+    timeout-minutes: 15
     permissions:
       contents: write
 
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      - name: Download release artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: release-dist
+          path: dist
 
-    - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v2
-
-    - name: Setup vcpkg
-      uses: lukka/run-vcpkg@v11
-      with:
-        vcpkgGitCommitId: 'af752f21c9d79ba3df9cb0250ce2233933f58486'
-
-    - name: Install dependencies
-      run: vcpkg install
-
-    - name: Determine version
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Stop'
-
-        $tag = '${{ github.ref_name }}'
-        $version = $tag
-        if ($version.StartsWith('v')) {
-          $version = $version.Substring(1)
-        }
-
-        if ([string]::IsNullOrWhiteSpace($version)) {
-          throw "Version is empty (tag: '$tag')"
-        }
-
-        "VERSION=$version" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
-
-    - name: Build (Release x64)
-      run: msbuild .\src\lastexecrecord.sln /m /p:Configuration=Release /p:Platform=x64
-
-    - name: Build (Release ARM64)
-      run: msbuild .\src\lastexecrecord.sln /m /p:Configuration=Release /p:Platform=ARM64
-
-    - name: Package (zip)
-      shell: pwsh
-      run: |
-        $ErrorActionPreference = 'Stop'
-
-        $workspace = $env:GITHUB_WORKSPACE
-        $dist = Join-Path $workspace 'dist'
-        New-Item -ItemType Directory -Force -Path $dist | Out-Null
-
-        $readmePath = Join-Path $workspace 'README.md'
-        if (-not (Test-Path $readmePath)) {
-          throw "README.md not found at $readmePath"
-        }
-
-        function New-PackageZip {
-          param(
-            [Parameter(Mandatory=$true)][string]$arch,
-            [Parameter(Mandatory=$true)][string]$platformFolder
-          )
-
-          $exe = Get-ChildItem -Path (Join-Path $workspace 'src') -Recurse -Filter 'lastexecuterecord.exe' |
-            Where-Object { $_.FullName -match "\\$platformFolder\\Release\\" } |
-            Select-Object -First 1
-
-          if (-not $exe) {
-            throw "Executable not found for $arch (expected under src\\$platformFolder\\Release\\): lastexecuterecord.exe"
-          }
-
-          $stageDir = Join-Path $dist $arch
-          if (Test-Path $stageDir) {
-            Remove-Item -Recurse -Force $stageDir
-          }
-          New-Item -ItemType Directory -Force -Path $stageDir | Out-Null
-
-          Copy-Item -Path $exe.FullName -Destination (Join-Path $stageDir $exe.Name) -Force
-          Copy-Item -Path $readmePath -Destination (Join-Path $stageDir 'README.md') -Force
-
-          $zipName = "lastexec_${env:VERSION}_${arch}.zip"
-          $zipPath = Join-Path $dist $zipName
-          if (Test-Path $zipPath) {
-            Remove-Item -Force $zipPath
-          }
-
-          Compress-Archive -Path (Join-Path $stageDir '*') -DestinationPath $zipPath
-        }
-
-        New-PackageZip -arch 'x64' -platformFolder 'x64'
-        New-PackageZip -arch 'arm64' -platformFolder 'ARM64'
-
-    - name: Publish GitHub Release
-      uses: softprops/action-gh-release@v2
-      with:
-        files: dist/*.zip
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*

--- a/README.md
+++ b/README.md
@@ -71,18 +71,18 @@ Example: `lastexecuterecord.sample.json`
 
 ### Root fields
 
-- `version` (number, optional): Default is 1
-- `networkOption` (number, optional): Control execution based on network status. Default is 2
+- `version` (integer, optional): Default is 1
+- `networkOption` (integer, optional): Control execution based on network status. Default is 2
   - `0`: Execute only when internet is connected (not on metered connections)
   - `1`: Execute even on metered connections (internet connection required)
   - `2`: Always execute (ignore network status)
-- `defaults.minIntervalSeconds` (number, optional): Default minimum interval for commands
-- `defaults.timeoutSeconds` (number, optional): Default timeout for commands
+- `defaults.minIntervalSeconds` (integer, optional): Default minimum interval for commands
+- `defaults.timeoutSeconds` (integer, optional): Default timeout for commands
 - `defaults.installerWaitBehavior` (string or number, optional): Default behavior when installer is running. Default is `"wait"`
   - `"wait"` or `0`: Wait for installer to finish before executing
   - `"skip"` or `1`: Skip command if installer is running
-- `defaults.installerWaitSeconds` (number, optional): Wait time in seconds between installer checks. Default is 30
-- `defaults.installerMaxRetries` (number, optional): Maximum number of retries when waiting. Default is 10
+- `defaults.installerWaitSeconds` (integer, optional): Wait time in seconds between installer checks. Default is 30
+- `defaults.installerMaxRetries` (integer, optional): Maximum number of retries when waiting. Default is 10
 - `commands` (array, required): List of commands to run (processed from top to bottom)
 
 ### Command fields
@@ -92,13 +92,15 @@ Example: `lastexecuterecord.sample.json`
 - `exe` (string, required): Executable path (**not a shell string; use exe + args**)
 - `args` (array of string, optional): Arguments
 - `workingDirectory` (string, optional)
-- `minIntervalSeconds` (number, optional): Defaults to `defaults.minIntervalSeconds`
-- `timeoutSeconds` (number, optional): Defaults to `defaults.timeoutSeconds`
+- `minIntervalSeconds` (integer, optional): Defaults to `defaults.minIntervalSeconds`
+- `timeoutSeconds` (integer, optional): Defaults to `defaults.timeoutSeconds`
 - `installerWaitBehavior` (string or number, optional): Behavior when installer is running. Defaults to `defaults.installerWaitBehavior`
-- `installerWaitSeconds` (number, optional): Wait time between checks. Defaults to `defaults.installerWaitSeconds`
-- `installerMaxRetries` (number, optional): Maximum retries. Defaults to `defaults.installerMaxRetries`
+- `installerWaitSeconds` (integer, optional): Wait time between checks. Defaults to `defaults.installerWaitSeconds`
+- `installerMaxRetries` (integer, optional): Maximum retries. Defaults to `defaults.installerMaxRetries`
 - `lastRunUtc` (string, optional): Example `2026-01-02T12:34:56Z` (seconds precision)
-- `lastExitCode` (number, optional): Previous exit code
+- `lastExitCode` (integer, optional): Previous exit code
+
+JSON must be strict JSON: comments, duplicate object keys, unescaped control characters, and fractional values for integer fields are rejected.
 
 ### sample(winget)
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,9 @@ After installation, you can run `lastexecuterecord.exe` from your terminal.
 - `lastexecuterecord.exe --config <path>`: Specify a custom config JSON path
 - `lastexecuterecord.exe --dry-run`: Do not execute; only show decisions
 - `lastexecuterecord.exe --verbose`: Verbose logs (including skip reasons)
+- `lastexecuterecord.exe --lock-timeout <seconds>`: Maximum time to wait for the config lock (default: 300)
 
-All options can be combined, for example: `lastexecuterecord.exe --config myconfig.json --dry-run --verbose`
+All options can be combined, for example: `lastexecuterecord.exe --config myconfig.json --dry-run --verbose --lock-timeout 60`
 
 ### Windows Terminal Profile Setup
 
@@ -89,9 +90,9 @@ Example: `lastexecuterecord.sample.json`
 
 - `name` (string, required): Display name / identifier
 - `enabled` (bool, optional): Default is true
-- `exe` (string, required): Executable path (**not a shell string; use exe + args**)
+- `exe` (string, required): Absolute path to an existing executable file (**not a shell string; use exe + args**)
 - `args` (array of string, optional): Arguments
-- `workingDirectory` (string, optional)
+- `workingDirectory` (string, optional): Absolute path to an existing directory when set
 - `minIntervalSeconds` (integer, optional): Defaults to `defaults.minIntervalSeconds`
 - `timeoutSeconds` (integer, optional): Defaults to `defaults.timeoutSeconds`
 - `installerWaitBehavior` (string or number, optional): Behavior when installer is running. Defaults to `defaults.installerWaitBehavior`

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Example: `lastexecuterecord.sample.json`
   - `0`: Execute only when internet is connected (not on metered connections)
   - `1`: Execute even on metered connections (internet connection required)
   - `2`: Always execute (ignore network status)
+  - If network status cannot be verified for option `0` or `1`, execution is skipped. `--verbose` prints the check failure code.
 - `defaults.minIntervalSeconds` (integer, optional): Default minimum interval for commands
 - `defaults.timeoutSeconds` (integer, optional): Default timeout for commands
 - `defaults.installerWaitBehavior` (string or number, optional): Default behavior when installer is running. Default is `"wait"`
@@ -132,7 +133,9 @@ JSON must be strict JSON: comments, duplicate object keys, unescaped control cha
 ## Notes (security)
 
 - The config uses `exe` + `args[]` and does not assume shell execution like `cmd.exe /c` (helps reduce injection risk).
+- `exe` must be an absolute path to an existing executable file. `workingDirectory`, when set, must be an absolute path to an existing directory.
 - To prevent concurrent runs, the program acquires an exclusive `<config>.lock` file.
+- Config updates are written atomically through a unique same-directory temporary file. The default lock wait is bounded to 300 seconds and can be changed with `--lock-timeout`.
 - **DO NOT** use environment variables or user input to construct `exe` or `args` in the config file, as this may lead to command injection vulnerabilities.
 
 ## Installer detection and wait behavior
@@ -172,7 +175,7 @@ This behavior is controlled by the `installerWaitBehavior` configuration field (
   "commands": [
     {
       "name": "system update",
-      "exe": "winget.exe",
+      "exe": "C:\\Windows\\System32\\sudo.exe",
       "args": ["upgrade", "--all"],
       "installerWaitBehavior": "wait"
     }
@@ -184,7 +187,7 @@ This behavior is controlled by the `installerWaitBehavior` configuration field (
 
 ### Building
 
-This project uses Visual Studio 2022/2025 or MSBuild.
+This project uses Visual Studio 2022/2026 or MSBuild.
 
 **Visual Studio:**
 ```cmd

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This behavior is controlled by the `installerWaitBehavior` configuration field (
     {
       "name": "system update",
       "exe": "C:\\Windows\\System32\\sudo.exe",
-      "args": ["upgrade", "--all"],
+      "args": ["winget", "upgrade", "--all"],
       "installerWaitBehavior": "wait"
     }
   ]

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -3,19 +3,21 @@
 This project **reads a configuration JSON**, **executes commands sequentially once per invocation**,
 and skips execution based on **last execution time (seconds precision)** and **minimum execution interval**.
 
-> Note: JSON comments are not supported.
+> Note: JSON comments are not supported. Duplicate object keys, unescaped control
+> characters in strings, non-JSON whitespace, and fractional values for integer
+> fields are rejected.
 
 ## Root
 
 | key | type | required | default | note |
 | --- | --- | --- | --- | --- |
-| `version` | number | no | 1 | Reserved for future use |
-| `networkOption` | number | no | 2 | Network-based execution control (0: connected only, 1: metered OK, 2: always execute) |
-| `defaults.minIntervalSeconds` | number | no | 0 | Default minimum interval for commands |
-| `defaults.timeoutSeconds` | number | no | 0 | Default timeout for commands (0 means unlimited) |
+| `version` | integer | no | 1 | Reserved for future use |
+| `networkOption` | integer | no | 2 | Network-based execution control (0: connected only, 1: metered OK, 2: always execute) |
+| `defaults.minIntervalSeconds` | integer | no | 0 | Default minimum interval for commands |
+| `defaults.timeoutSeconds` | integer | no | 0 | Default timeout for commands (0 means unlimited) |
 | `defaults.installerWaitBehavior` | string or number | no | "wait" | Default behavior when installer is running ("wait" or "skip", or 0/1) |
-| `defaults.installerWaitSeconds` | number | no | 30 | Default wait time in seconds between installer checks |
-| `defaults.installerMaxRetries` | number | no | 10 | Default maximum number of retries when waiting for installer |
+| `defaults.installerWaitSeconds` | integer | no | 30 | Default wait time in seconds between installer checks |
+| `defaults.installerMaxRetries` | integer | no | 10 | Default maximum number of retries when waiting for installer |
 | `commands` | array | yes | - | Commands to execute in order from top to bottom |
 
 ## Command
@@ -27,13 +29,13 @@ and skips execution based on **last execution time (seconds precision)** and **m
 | `exe` | string | yes | - | Executable file path (not a shell command) |
 | `args` | array of string | no | [] | Arguments |
 | `workingDirectory` | string | no | "" | Working directory |
-| `minIntervalSeconds` | number | no | `defaults.minIntervalSeconds` | Used for skip decision |
-| `timeoutSeconds` | number | no | `defaults.timeoutSeconds` | 0 means unlimited |
+| `minIntervalSeconds` | integer | no | `defaults.minIntervalSeconds` | Used for skip decision |
+| `timeoutSeconds` | integer | no | `defaults.timeoutSeconds` | 0 means unlimited |
 | `installerWaitBehavior` | string or number | no | `defaults.installerWaitBehavior` | Behavior when installer is running ("wait" or "skip", or 0/1) |
-| `installerWaitSeconds` | number | no | `defaults.installerWaitSeconds` | Wait time in seconds between installer checks |
-| `installerMaxRetries` | number | no | `defaults.installerMaxRetries` | Maximum number of retries when waiting for installer |
+| `installerWaitSeconds` | integer | no | `defaults.installerWaitSeconds` | Wait time in seconds between installer checks |
+| `installerMaxRetries` | integer | no | `defaults.installerMaxRetries` | Maximum number of retries when waiting for installer |
 | `lastRunUtc` | string | no | - | `YYYY-MM-DDTHH:MM:SSZ` (UTC, seconds precision) |
-| `lastExitCode` | number | no | - | Previous exit code |
+| `lastExitCode` | integer | no | - | Previous exit code |
 
 ## Time format
 

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -26,9 +26,9 @@ and skips execution based on **last execution time (seconds precision)** and **m
 | --- | --- | --- | --- | --- |
 | `name` | string | yes | - | Display name/identifier (`id` is also accepted as an alternative to name) |
 | `enabled` | bool | no | true | Always skip if false |
-| `exe` | string | yes | - | Executable file path (not a shell command) |
+| `exe` | string | yes | - | Absolute path to an existing executable file (not a shell command) |
 | `args` | array of string | no | [] | Arguments |
-| `workingDirectory` | string | no | "" | Working directory |
+| `workingDirectory` | string | no | "" | Absolute path to an existing directory when set |
 | `minIntervalSeconds` | integer | no | `defaults.minIntervalSeconds` | Used for skip decision |
 | `timeoutSeconds` | integer | no | `defaults.timeoutSeconds` | 0 means unlimited |
 | `installerWaitBehavior` | string or number | no | `defaults.installerWaitBehavior` | Behavior when installer is running ("wait" or "skip", or 0/1) |

--- a/docs/config-schema.md
+++ b/docs/config-schema.md
@@ -49,6 +49,7 @@ and skips execution based on **last execution time (seconds precision)** and **m
   - `1`: Execute even on metered connections (internet connection required)
   - `2`: Always execute (regardless of network status) - Default
 - Network check is performed once at startup, and all commands are skipped if the condition is not met
+- For options `0` and `1`, if network status cannot be verified, execution is skipped. In `--verbose` mode the failure code is printed.
 
 ## Skip logic
 
@@ -72,6 +73,7 @@ The application can detect when Windows installer processes (such as `msiexec.ex
   - Default: wait 30 seconds, retry up to 10 times (total wait: up to 300 seconds)
 - When skipping (`installerWaitBehavior` is `"skip"`):
   - The command is immediately skipped if an installer is detected
+- If installer status cannot be verified, verbose mode prints a warning and execution proceeds. This avoids blocking command execution on an unverifiable installer state.
 
 **Detected installer processes:**
 - `msiexec.exe` (Windows Installer)

--- a/docs/handover.md
+++ b/docs/handover.md
@@ -72,9 +72,10 @@ README には「NTFS data stream (ADS) に最終実行時刻を記録」とだ�
 
 ### 4.1 CLI
 
-- `--config PATH` : config JSON を指定（未指定なら exe と同名の `.json`）
+- `--config PATH` : config JSON を指定（未指定なら `%USERPROFILE%\.lastexecrecord\config.json`）
 - `--dry-run` : 実行せず、実行/スキップの判定だけ表示
 - `--verbose` : 詳細ログ（スキップ理由など）
+- `--lock-timeout SECONDS` : config lock の待機上限（既定 300 秒）
 
 ### 4.2 スキップ条件
 
@@ -94,13 +95,17 @@ README には「NTFS data stream (ADS) に最終実行時刻を記録」とだ�
 - File I/O: `src/lastexecuterecord/FileUtil.h/.cpp`
 - Time: `src/lastexecuterecord/TimeUtil.h/.cpp`
 - Process: `src/lastexecuterecord/CommandRunner.h/.cpp`
+- Network: `src/lastexecuterecord/NetworkUtil.h/.cpp`
+- Installer: `src/lastexecuterecord/InstallerUtil.h/.cpp`
 
 ## 6. 既知の制約 / 今後の改善候補
 
 - この環境では msbuild が見つからず、こちら側での実ビルド検証は未実施（VS/Build Tools 環境で確認が必要）。
-- exe パスの絶対パス強制や正規化は現状最小限（必要なら Win32 API で強化）。
+- exe パスは絶対パスかつ既存ファイル必須。`workingDirectory` も指定時は絶対パスかつ既存ディレクトリ必須。
 - `cmd.exe` / `powershell.exe` を禁止しているわけではない（exe に指定すれば動く）。
   - セキュリティ優先なら禁止ポリシーや allow-list の導入を検討。
+- `networkOption` がネットワーク状態を要求する場合、状態を検証できなければ fail closed でスキップする。
+- installer 状態を検証できない場合は verbose 警告を出し、ブロック回避のため実行を継続する。
 - config 更新を「成功時のみ」にする/「開始時に予約する」などのポリシー確定が必要。
 - ADS（NTFS data stream）へ記録する要件が復活した場合は、state専用ファイルの ADS に JSON を保存する方式を検討。
 

--- a/docs/implementation-map.md
+++ b/docs/implementation-map.md
@@ -27,6 +27,7 @@
   - `readUtf8FileToWString(path)`
   - `writeWStringToUtf8FileAtomic(path, content)`
   - `acquireLockFile(path)`
+  - path helpers: `getFullPath(path)`, `pathIsAbsolute(path)`, `fileExists(path)`, `directoryExists(path)`
 
 ## Time
 

--- a/docs/implementation-map.md
+++ b/docs/implementation-map.md
@@ -52,7 +52,8 @@
 
 ## Installer detection
 
-- `src/lastexecuterecord/InstallerUtil.h/.cpp`
+  - `src/lastexecuterecord/InstallerUtil.h/.cpp`
+  - `checkInstallerRunning()` - Returns Running/NotRunning/CheckFailed status
   - `isInstallerRunning()` - Checks if installer processes (msiexec.exe, setup.exe, etc.) are running
   - `waitForInstallerToFinish(waitSeconds, maxRetries)` - Waits for installer to finish with retries
   - Uses `CreateToolhelp32Snapshot` and process enumeration APIs

--- a/docs/implementation-map.md
+++ b/docs/implementation-map.md
@@ -5,9 +5,9 @@
 ## Entry point
 
 - `src/lastexecuterecord/main.cpp`
-  - `wmain` 実装
-  - `--config`, `--dry-run`, `--verbose`
-  - コマンドの順次実行、スキップ判定、config の更新
+   - `wmain` 実装
+   - `--config`, `--dry-run`, `--verbose`, `--lock-timeout`
+   - コマンドの順次実行、スキップ判定、config の更新
 
 ## Config
 
@@ -45,10 +45,11 @@
 ## Network checking
 
 - `src/lastexecuterecord/NetworkUtil.h/.cpp`
-  - `hasInternetConnection()`
-  - `isConnectionMetered()`
-  - `shouldExecuteBasedOnNetwork(option)`
-  - `NetworkOption` enum: ExecuteWhenConnected(0), ExecuteOnMetered(1), AlwaysExecute(2)
+   - `hasInternetConnection()`
+   - `isConnectionMetered()`
+   - `shouldExecuteBasedOnNetwork(option)`
+   - `evaluateNetworkOption(option)` - returns whether execution should proceed and whether network status was verified
+   - `NetworkOption` enum: ExecuteWhenConnected(0), ExecuteOnMetered(1), AlwaysExecute(2)
 
 ## Installer detection
 

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -40,5 +40,5 @@ This tool "controls process execution via configuration JSON", so protecting the
 - No administrator privileges required to enumerate processes (works with standard user).
 - Process name comparison is case-insensitive for reliability.
 - Detection is limited to common installer process names (`msiexec.exe`, `setup.exe`, etc.).
-- Failed snapshot creation (e.g., insufficient permissions) is treated as "no installer running" to avoid blocking execution.
+- Failed snapshot creation is represented as `CheckFailed`; verbose mode logs a warning and execution proceeds to avoid blocking on an unverifiable installer state.
 - The handle to the snapshot is explicitly closed using `CloseHandle` to avoid resource leaks.

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -33,6 +33,7 @@ This tool "controls process execution via configuration JSON", so protecting the
 - Network status check is performed once at startup and uses COM.
 - COM initialization is done within functions and does not re-initialize if already initialized.
 - No administrator privileges required to access network information (works with standard user).
+- Network-gated modes fail closed: if network status cannot be verified for `ExecuteWhenConnected` or `ExecuteOnMetered`, commands are skipped and verbose mode reports the error code.
 
 ## 6. Installer detection
 

--- a/docs/security-notes.md
+++ b/docs/security-notes.md
@@ -5,12 +5,16 @@ This tool "controls process execution via configuration JSON", so protecting the
 ## 1. Command injection prevention
 
 - Uses `exe` and `args[]` separation with `CreateProcessW`.
+- Requires `exe` to be an absolute path to an existing file before execution.
+- Requires `workingDirectory`, when set, to be an absolute path to an existing directory.
 - Does not use shell execution methods like `cmd.exe /c` (however, if `cmd.exe` is specified in `exe`, it can be executed, so additional policies are needed to prohibit it).
 
 ## 2. Concurrent execution and corruption prevention
 
 - Prevents multiple simultaneous runs by exclusively opening `<config>.lock`.
-- Config updates are atomic: write to `.tmp` → replace with `MoveFileEx(REPLACE_EXISTING|WRITE_THROUGH)`.
+- The config path is normalized before deriving `<config>.lock`, reducing lock bypass via path aliases.
+- Config updates are atomic: write to a unique same-directory temporary file → replace with `MoveFileEx(REPLACE_EXISTING|WRITE_THROUGH)`.
+- Lock acquisition is bounded by `--lock-timeout` (default: 300 seconds).
 
 ## 3. Recommended practices
 
@@ -20,7 +24,6 @@ This tool "controls process execution via configuration JSON", so protecting the
 
 ## 4. Future enhancements
 
-- Enforce absolute path and normalization for `exe`.
 - Allow-list to prohibit/restrict `cmd.exe`, `powershell.exe`, etc.
 - Signature/hash verification for `exe` (depending on requirements).
 

--- a/src/README.md
+++ b/src/README.md
@@ -2,13 +2,13 @@
 
 This directory contains the source code for the project. It is organized as follows:
 
-- `lastexecuterecord`: Visual Studio 2022/2025 project for the `lastexecuterecord` console application.
+- `lastexecuterecord`: Visual Studio 2022/2026 project for the `lastexecuterecord` console application.
 - `lastexecuterecord.core`: Static library containing core functionality (TimeUtil, Json, Config, FileUtil, CommandRunner).
 - `lastexecuterecord.mstest`: Native Unit Test Project using Microsoft Unit Testing Framework for C++.
 
 The `lastexecuterecord` project includes:
 
-- A Visual Studio 2022/2025 project file (`lastexecuterecord.vcxproj`) configured for Unicode.
+- A Visual Studio 2022/2026 project file (`lastexecuterecord.vcxproj`) configured for Unicode.
 - A filters file (`lastexecuterecord.vcxproj.filters`) for organizing the project files.
 - A `main.cpp` entry point that links to the core library.
 

--- a/src/README.vcpkg-tests.md
+++ b/src/README.vcpkg-tests.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Visual Studio 2022/2025 with C++ workload
+- Visual Studio 2022/2026 with C++ workload
 - Microsoft Unit Testing Framework for C++ (included with Visual Studio)
 
 ## Build and run

--- a/src/lastexecuterecord.core/lastexecuterecord.core.vcxproj
+++ b/src/lastexecuterecord.core/lastexecuterecord.core.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM64">
@@ -90,10 +90,19 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -107,18 +116,21 @@
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <PreprocessorDefinitions>UNICODE;_UNICODE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/lastexecuterecord.mstest/CommandRunnerTests.cpp
+++ b/src/lastexecuterecord.mstest/CommandRunnerTests.cpp
@@ -13,6 +13,11 @@ namespace lastexecuterecordmstest
 			Assert::AreEqual(std::wstring(L"abc"), ler::quoteArgForWindowsCommandLine(L"abc"));
 		}
 
+		TEST_METHOD(QuoteArg_Empty_ReturnsQuotedEmpty)
+		{
+			Assert::AreEqual(std::wstring(L"\"\""), ler::quoteArgForWindowsCommandLine(L""));
+		}
+
 		TEST_METHOD(QuoteArg_WithSpace_AddsQuotes)
 		{
 			Assert::AreEqual(std::wstring(L"\"a b\""), ler::quoteArgForWindowsCommandLine(L"a b"));

--- a/src/lastexecuterecord.mstest/ConfigTests.cpp
+++ b/src/lastexecuterecord.mstest/ConfigTests.cpp
@@ -23,6 +23,25 @@ namespace lastexecuterecordmstest
 		return path;
 	}
 
+	static std::wstring jsonEscapeString(const std::wstring& value) {
+		std::wstring escaped;
+		for (wchar_t c : value) {
+			if (c == L'\\' || c == L'"') {
+				escaped.push_back(L'\\');
+			}
+			escaped.push_back(c);
+		}
+		return escaped;
+	}
+
+	static std::wstring validExePath() {
+		return ler::joinPath(ler::getSystemDirectoryPath(), L"whoami.exe");
+	}
+
+	static std::wstring validExeForJson() {
+		return jsonEscapeString(validExePath());
+	}
+
 	// RAII helper for temp files
 	class TempFile {
 	public:
@@ -110,7 +129,7 @@ namespace lastexecuterecordmstest
 				L"{\n"
 				L"  \"version\": 1,\n"
 				L"  \"commands\": [\n"
-				L"    { \"name\": \"custom\", \"exe\": \"test.exe\" }\n"
+				L"    { \"name\": \"custom\", \"exe\": \"" + validExeForJson() + L"\" }\n"
 				L"  ]\n"
 				L"}\n";
 			ler::writeWStringToUtf8FileAtomic(configPath, customContent);
@@ -158,14 +177,83 @@ namespace lastexecuterecordmstest
 				L"{\n"
 				L"  \"version\": 1,\n"
 				L"  \"commands\": [\n"
-				L"    { \"name\": \"c1\", \"exe\": \"C:\\\\Windows\\\\System32\\\\whoami.exe\" }\n"
+				L"    { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" }\n"
 				L"  ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
 			Assert::AreEqual(1u, static_cast<unsigned>(cfg.commands.size()));
 			Assert::AreEqual(std::wstring(L"c1"), cfg.commands[0].name);
-			Assert::AreEqual(std::wstring(L"C:\\Windows\\System32\\whoami.exe"), cfg.commands[0].exe);
+			Assert::AreEqual(validExePath(), cfg.commands[0].exe);
+		}
+
+		TEST_METHOD(Load_CommandExeRelative_Throws)
+		{
+			TempFile tmp(L"relativeexe.json");
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"whoami.exe\" } ]\n"
+				L"}\n");
+
+			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Load_CommandExeMissingFile_Throws)
+		{
+			TempFile tmp(L"missingexe.json");
+			std::wstring missingExe = jsonEscapeString(makeTempPath(L"missing.exe"));
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + missingExe + L"\" } ]\n"
+				L"}\n");
+
+			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Load_WorkingDirectoryRelative_Throws)
+		{
+			TempFile tmp(L"relativewd.json");
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\", \"workingDirectory\": \"relative\" } ]\n"
+				L"}\n");
+
+			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Load_WorkingDirectoryMissing_Throws)
+		{
+			TempFile tmp(L"missingwd.json");
+			std::wstring missingDir = jsonEscapeString(makeTempPath(L"missing_dir"));
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\", \"workingDirectory\": \"" + missingDir + L"\" } ]\n"
+				L"}\n");
+
+			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Load_WorkingDirectoryAbsoluteExisting_ParsesCorrectly)
+		{
+			TempDirectory tempDir(L"validwd");
+			CreateDirectoryW(tempDir.path.c_str(), nullptr);
+			TempFile tmp(L"validwd.json");
+
+			ler::writeWStringToUtf8FileAtomic(tmp.path,
+				L"{\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\", \"workingDirectory\": \"" + jsonEscapeString(tempDir.path) + L"\" } ]\n"
+				L"}\n");
+
+			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
+			Assert::AreEqual(tempDir.path, cfg.commands[0].workingDirectory);
 		}
 
 		TEST_METHOD(Load_CommandNameMissing_Throws)
@@ -200,7 +288,7 @@ namespace lastexecuterecordmstest
 
 			ler::writeWStringToUtf8FileAtomic(tmp.path,
 				L"{\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -220,7 +308,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"lastRunUtc\": \"2026-01-02T12:34:56Z\",\n"
 				L"      \"lastExitCode\": 0\n"
 				L"    }\n"
@@ -241,7 +329,7 @@ namespace lastexecuterecordmstest
 
 			ler::writeWStringToUtf8FileAtomic(tmp.path,
 				L"{\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -270,7 +358,7 @@ namespace lastexecuterecordmstest
 			ler::writeWStringToUtf8FileAtomic(tmp.path,
 				L"{\n"
 				L"  \"networkOption\": 1,\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -283,7 +371,7 @@ namespace lastexecuterecordmstest
 
 			ler::writeWStringToUtf8FileAtomic(tmp.path,
 				L"{\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -297,7 +385,7 @@ namespace lastexecuterecordmstest
 			ler::writeWStringToUtf8FileAtomic(tmp.path,
 				L"{\n"
 				L"  \"networkOption\": 5,\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
@@ -311,7 +399,7 @@ namespace lastexecuterecordmstest
 			ler::writeWStringToUtf8FileAtomic(tmp.path,
 				L"{\n"
 				L"  \"networkOption\": -1,\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			auto func = [&tmp]() { ler::loadAndValidateConfig(tmp.path); };
@@ -327,7 +415,7 @@ namespace lastexecuterecordmstest
 				L"  \"defaults\": {\n"
 				L"    \"networkOption\": 0\n"
 				L"  },\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -344,7 +432,7 @@ namespace lastexecuterecordmstest
 				L"  \"defaults\": {\n"
 				L"    \"networkOption\": 0\n"
 				L"  },\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -360,7 +448,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerWaitBehavior\": \"wait\"\n"
 				L"    }\n"
 				L"  ]\n"
@@ -380,7 +468,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerWaitBehavior\": \"skip\"\n"
 				L"    }\n"
 				L"  ]\n"
@@ -400,7 +488,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerWaitBehavior\": 1\n"
 				L"    }\n"
 				L"  ]\n"
@@ -420,7 +508,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerWaitBehavior\": \"invalid\"\n"
 				L"    }\n"
 				L"  ]\n"
@@ -439,7 +527,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerWaitSeconds\": 60\n"
 				L"    }\n"
 				L"  ]\n"
@@ -459,7 +547,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerMaxRetries\": 5\n"
 				L"    }\n"
 				L"  ]\n"
@@ -481,7 +569,7 @@ namespace lastexecuterecordmstest
 				L"    \"installerWaitSeconds\": 45,\n"
 				L"    \"installerMaxRetries\": 20\n"
 				L"  },\n"
-				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"x.exe\" } ]\n"
+				L"  \"commands\": [ { \"name\": \"c1\", \"exe\": \"" + validExeForJson() + L"\" } ]\n"
 				L"}\n");
 
 			ler::AppConfig cfg = ler::loadAndValidateConfig(tmp.path);
@@ -503,7 +591,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerWaitSeconds\": -5\n"
 				L"    }\n"
 				L"  ]\n"
@@ -522,7 +610,7 @@ namespace lastexecuterecordmstest
 				L"  \"commands\": [\n"
 				L"    {\n"
 				L"      \"name\": \"c1\",\n"
-				L"      \"exe\": \"x.exe\",\n"
+				L"      \"exe\": \"" + validExeForJson() + L"\",\n"
 				L"      \"installerMaxRetries\": -1\n"
 				L"    }\n"
 				L"  ]\n"

--- a/src/lastexecuterecord.mstest/FileUtilTests.cpp
+++ b/src/lastexecuterecord.mstest/FileUtilTests.cpp
@@ -56,6 +56,20 @@ namespace lastexecuterecordmstest
 			Assert::AreEqual(std::wstring(L"replaced"), read2);
 		}
 
+		TEST_METHOD(Write_AtomicReplace_DoesNotUseFixedTmpPath)
+		{
+			TempFile tmp(L"fixedtmp.txt");
+			std::wstring fixedTmp = tmp.path + L".tmp";
+
+			ler::writeWStringToUtf8FileAtomic(fixedTmp, L"collision");
+			ler::writeWStringToUtf8FileAtomic(tmp.path, L"target");
+
+			Assert::AreEqual(std::wstring(L"target"), ler::readUtf8FileToWString(tmp.path));
+			Assert::AreEqual(std::wstring(L"collision"), ler::readUtf8FileToWString(fixedTmp));
+
+			DeleteFileW(fixedTmp.c_str());
+		}
+
 		TEST_METHOD(Read_EmptyFile_ReturnsEmpty)
 		{
 			TempFile tmp(L"empty.txt");
@@ -139,6 +153,19 @@ namespace lastexecuterecordmstest
 		{
 			std::wstring result = ler::getDirectoryName(L"C:\\temp\\file.txt");
 			Assert::AreEqual(std::wstring(L"C:\\temp"), result);
+		}
+
+		TEST_METHOD(PathIsAbsolute_DetectsDriveAbsolutePath)
+		{
+			Assert::IsTrue(ler::pathIsAbsolute(L"C:\\temp\\file.txt"));
+			Assert::IsFalse(ler::pathIsAbsolute(L"temp\\file.txt"));
+		}
+
+		TEST_METHOD(GetFullPath_NormalizesRelativePath)
+		{
+			std::wstring full = ler::getFullPath(L".");
+			Assert::IsTrue(ler::pathIsAbsolute(full));
+			Assert::IsTrue(ler::directoryExists(full));
 		}
 	};
 }

--- a/src/lastexecuterecord.mstest/InstallerUtilTests.cpp
+++ b/src/lastexecuterecord.mstest/InstallerUtilTests.cpp
@@ -21,6 +21,16 @@ namespace lastexecuterecordmstest
 			(void)result; // Acknowledge we're not asserting the value
 		}
 
+		TEST_METHOD(CheckInstallerRunning_ReturnsKnownStatus)
+		{
+			ler::InstallerCheckResult result = ler::checkInstallerRunning();
+			bool knownStatus =
+				result.status == ler::InstallerCheckStatus::NotRunning ||
+				result.status == ler::InstallerCheckStatus::Running ||
+				result.status == ler::InstallerCheckStatus::CheckFailed;
+			Assert::IsTrue(knownStatus);
+		}
+
 		TEST_METHOD(WaitForInstallerToFinish_ReturnsBoolean)
 		{
 			// Verify the function handles edge cases gracefully

--- a/src/lastexecuterecord.mstest/JsonTests.cpp
+++ b/src/lastexecuterecord.mstest/JsonTests.cpp
@@ -112,5 +112,54 @@ namespace lastexecuterecordmstest
 			auto func = []() { ler::parseJson(L"{invalid}"); };
 			Assert::ExpectException<std::runtime_error>(func);
 		}
+
+		TEST_METHOD(Parse_UnterminatedString_Throws)
+		{
+			auto func = []() { ler::parseJson(L"\"unterminated"); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Parse_RawControlCharacterInString_Throws)
+		{
+			auto func = []() { ler::parseJson(L"\"line\nbreak\""); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Parse_LoneHighSurrogate_Throws)
+		{
+			auto func = []() { ler::parseJson(L"\"\\uD800\""); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Parse_LoneLowSurrogate_Throws)
+		{
+			auto func = []() { ler::parseJson(L"\"\\uDC00\""); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Parse_DuplicateObjectKey_Throws)
+		{
+			auto func = []() { ler::parseJson(L"{\"a\":1,\"a\":2}"); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Parse_NonJsonWhitespace_Throws)
+		{
+			auto func = []() { ler::parseJson(L"\vtrue"); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(Parse_IntegerOverflow_Throws)
+		{
+			auto func = []() { ler::parseJson(L"9223372036854775808"); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
+
+		TEST_METHOD(AsInt_Double_Throws)
+		{
+			ler::JsonValue v = ler::parseJson(L"1.9");
+			auto func = [&v]() { v.asInt(L"ctx"); };
+			Assert::ExpectException<ler::JsonParseError>(func);
+		}
 	};
 }

--- a/src/lastexecuterecord.mstest/NetworkUtilTests.cpp
+++ b/src/lastexecuterecord.mstest/NetworkUtilTests.cpp
@@ -31,6 +31,22 @@ namespace lastexecuterecordmstest
 			Assert::IsTrue(result);
 		}
 
+		TEST_METHOD(EvaluateNetworkOption_AlwaysExecute_ReturnsKnownTrue)
+		{
+			ler::NetworkDecision decision = ler::evaluateNetworkOption(ler::NetworkOption::AlwaysExecute);
+			Assert::IsTrue(decision.statusKnown);
+			Assert::IsTrue(decision.shouldExecute);
+			Assert::AreEqual(0u, decision.errorCode);
+		}
+
+		TEST_METHOD(EvaluateNetworkOption_Invalid_ReturnsUnknownFalse)
+		{
+			ler::NetworkDecision decision = ler::evaluateNetworkOption(static_cast<ler::NetworkOption>(99));
+			Assert::IsFalse(decision.statusKnown);
+			Assert::IsFalse(decision.shouldExecute);
+			Assert::AreNotEqual(0u, decision.errorCode);
+		}
+
 		TEST_METHOD(ShouldExecuteBasedOnNetwork_ExecuteOnMetered_DoesNotCrash)
 		{
 			// NetworkOption::ExecuteOnMetered (1) depends on connection state

--- a/src/lastexecuterecord/CommandRunner.cpp
+++ b/src/lastexecuterecord/CommandRunner.cpp
@@ -169,6 +169,11 @@ RunResult runProcess(const std::wstring& exePath,
             rr.exitCode = GetLastError();
             return rr;
         }
+        if (terminateWait == WAIT_TIMEOUT) {
+            // Process did not exit within the termination grace period.
+            rr.exitCode = static_cast<DWORD>(STILL_ACTIVE);
+            return rr;
+        }
     }
     else if (w == WAIT_FAILED) {
         rr.exitCode = GetLastError();

--- a/src/lastexecuterecord/CommandRunner.cpp
+++ b/src/lastexecuterecord/CommandRunner.cpp
@@ -6,8 +6,51 @@
 
 namespace ler {
 
+namespace {
+
+class ScopedHandle {
+public:
+    ScopedHandle() = default;
+    explicit ScopedHandle(HANDLE handle) : h_(handle) {}
+    ScopedHandle(const ScopedHandle&) = delete;
+    ScopedHandle& operator=(const ScopedHandle&) = delete;
+
+    ScopedHandle(ScopedHandle&& other) noexcept : h_(other.h_) {
+        other.h_ = INVALID_HANDLE_VALUE;
+    }
+
+    ScopedHandle& operator=(ScopedHandle&& other) noexcept {
+        if (this != &other) {
+            reset();
+            h_ = other.h_;
+            other.h_ = INVALID_HANDLE_VALUE;
+        }
+        return *this;
+    }
+
+    ~ScopedHandle() {
+        reset();
+    }
+
+    HANDLE get() const { return h_; }
+
+    void reset(HANDLE handle = INVALID_HANDLE_VALUE) {
+        if (h_ != INVALID_HANDLE_VALUE && h_ != nullptr) {
+            CloseHandle(h_);
+        }
+        h_ = handle;
+    }
+
+private:
+    HANDLE h_ = INVALID_HANDLE_VALUE;
+};
+
+} // namespace
+
 std::wstring quoteArgForWindowsCommandLine(const std::wstring& arg) {
     // Rules aligned with CommandLineToArgvW / MS C runtime parsing.
+    if (arg.empty()) return L"\"\"";
+
     bool needsQuotes = false;
     for (wchar_t c : arg) {
         if (c == L' ' || c == L'\t' || c == L'\n' || c == L'\v' || c == L'\"') {
@@ -101,6 +144,8 @@ RunResult runProcess(const std::wstring& exePath,
     }
 
     rr.started = true;
+    ScopedHandle threadHandle(pi.hThread);
+    ScopedHandle processHandle(pi.hProcess);
 
     DWORD waitMs = INFINITE;
     if (timeoutSeconds > 0) {
@@ -112,19 +157,30 @@ RunResult runProcess(const std::wstring& exePath,
         }
     }
 
-    DWORD w = WaitForSingleObject(pi.hProcess, waitMs);
+    DWORD w = WaitForSingleObject(processHandle.get(), waitMs);
     if (w == WAIT_TIMEOUT) {
         rr.timedOut = true;
-        TerminateProcess(pi.hProcess, 1);
-        WaitForSingleObject(pi.hProcess, 5000);
+        if (!TerminateProcess(processHandle.get(), 1)) {
+            rr.exitCode = GetLastError();
+            return rr;
+        }
+        DWORD terminateWait = WaitForSingleObject(processHandle.get(), 5000);
+        if (terminateWait == WAIT_FAILED) {
+            rr.exitCode = GetLastError();
+            return rr;
+        }
+    }
+    else if (w == WAIT_FAILED) {
+        rr.exitCode = GetLastError();
+        return rr;
     }
 
     DWORD ec = 0;
-    if (!GetExitCodeProcess(pi.hProcess, &ec)) ec = 1;
+    if (!GetExitCodeProcess(processHandle.get(), &ec)) {
+        rr.exitCode = GetLastError();
+        return rr;
+    }
     rr.exitCode = ec;
-
-    CloseHandle(pi.hThread);
-    CloseHandle(pi.hProcess);
 
     return rr;
 }

--- a/src/lastexecuterecord/Config.cpp
+++ b/src/lastexecuterecord/Config.cpp
@@ -82,12 +82,16 @@ static void upsertObjectField(JsonValue& obj, const std::wstring& key, JsonValue
 
 static void validateExecutablePath(CommandConfig& command) {
     if (!pathIsAbsolute(command.exe)) {
-        throw JsonParseError("command.exe must be an absolute path: " + narrowForError(command.name));
+        throw JsonParseError(
+            "command.exe must be an absolute path: " + narrowForError(command.exe) +
+            " (command name: " + narrowForError(command.name) + ")");
     }
 
     command.exe = getFullPath(command.exe);
     if (!fileExists(command.exe)) {
-        throw JsonParseError("command.exe must refer to an existing file: " + narrowForError(command.name));
+        throw JsonParseError(
+            "command.exe must refer to an existing file: " + narrowForError(command.exe) +
+            " (command name: " + narrowForError(command.name) + ")");
     }
 }
 
@@ -95,12 +99,18 @@ static void validateWorkingDirectory(CommandConfig& command) {
     if (command.workingDirectory.empty()) return;
 
     if (!pathIsAbsolute(command.workingDirectory)) {
-        throw JsonParseError("command.workingDirectory must be an absolute path: " + narrowForError(command.name));
+        throw JsonParseError(
+            "command.workingDirectory must be an absolute path for command '" +
+            narrowForError(command.name) + "': " +
+            narrowForError(command.workingDirectory));
     }
 
     command.workingDirectory = getFullPath(command.workingDirectory);
     if (!directoryExists(command.workingDirectory)) {
-        throw JsonParseError("command.workingDirectory must refer to an existing directory: " + narrowForError(command.name));
+        throw JsonParseError(
+            "command.workingDirectory must refer to an existing directory for command '" +
+            narrowForError(command.name) + "': " +
+            narrowForError(command.workingDirectory));
     }
 }
 

--- a/src/lastexecuterecord/Config.cpp
+++ b/src/lastexecuterecord/Config.cpp
@@ -8,9 +8,18 @@
 
 namespace ler {
 
+static std::string narrowForError(const std::wstring& value) {
+    std::string out;
+    out.reserve(value.size());
+    for (wchar_t c : value) {
+        out.push_back(c >= 0 && c <= 0x7F ? static_cast<char>(c) : '?');
+    }
+    return out;
+}
+
 static const JsonValue& requireObjectField(const JsonValue& obj, const std::wstring& key, const wchar_t* ctx) {
     const JsonValue* v = obj.tryGet(key);
-    if (!v) throw JsonParseError(std::string("Missing field: ") + std::string(key.begin(), key.end()) + " at " + std::string(std::wstring(ctx).begin(), std::wstring(ctx).end()));
+    if (!v) throw JsonParseError("Missing field: " + narrowForError(key) + " at " + narrowForError(ctx ? std::wstring(ctx) : std::wstring()));
     return *v;
 }
 
@@ -55,7 +64,7 @@ static InstallerWaitBehavior getInstallerWaitBehaviorOrDefault(const JsonValue& 
     }
     // Invalid type - throw error instead of silently returning default
     std::string msg = "Invalid type for field ";
-    msg += std::string(key.begin(), key.end());
+    msg += narrowForError(key);
     msg += " in installerWaitBehavior; expected string or integer";
     throw JsonParseError(msg);
 }
@@ -69,6 +78,30 @@ static void upsertObjectField(JsonValue& obj, const std::wstring& key, JsonValue
         }
     }
     obj.o.push_back(std::make_pair(key, std::move(value)));
+}
+
+static void validateExecutablePath(CommandConfig& command) {
+    if (!pathIsAbsolute(command.exe)) {
+        throw JsonParseError("command.exe must be an absolute path: " + narrowForError(command.name));
+    }
+
+    command.exe = getFullPath(command.exe);
+    if (!fileExists(command.exe)) {
+        throw JsonParseError("command.exe must refer to an existing file: " + narrowForError(command.name));
+    }
+}
+
+static void validateWorkingDirectory(CommandConfig& command) {
+    if (command.workingDirectory.empty()) return;
+
+    if (!pathIsAbsolute(command.workingDirectory)) {
+        throw JsonParseError("command.workingDirectory must be an absolute path: " + narrowForError(command.name));
+    }
+
+    command.workingDirectory = getFullPath(command.workingDirectory);
+    if (!directoryExists(command.workingDirectory)) {
+        throw JsonParseError("command.workingDirectory must refer to an existing directory: " + narrowForError(command.name));
+    }
 }
 
 static std::wstring sampleConfigText() {
@@ -88,8 +121,8 @@ static std::wstring sampleConfigText() {
     s += L"    {\n";
     s += L"      \"name\": \"example (disabled)\",\n";
     s += L"      \"enabled\": false,\n";
-    s += L"      \"exe\": \"C:\\\\Windows\\\\System32\\\\cmd.exe\",\n";
-    s += L"      \"args\": [\"/c\", \"echo Hello from LastExecuteRecord\"]\n";
+    s += L"      \"exe\": \"C:\\\\Windows\\\\System32\\\\whoami.exe\",\n";
+    s += L"      \"args\": []\n";
     s += L"    }\n";
     s += L"  ]\n";
     s += L"}\n";
@@ -194,6 +227,7 @@ AppConfig loadAndValidateConfig(const std::wstring& configPath) {
         if (cc.exe.empty()) {
             throw JsonParseError("command.exe is required");
         }
+        validateExecutablePath(cc);
 
         // args
         const JsonValue* argsV = c.tryGet(L"args");
@@ -205,6 +239,7 @@ AppConfig loadAndValidateConfig(const std::wstring& configPath) {
         }
 
         cc.workingDirectory = getStringFieldOrEmpty(c, L"workingDirectory");
+        validateWorkingDirectory(cc);
 
         cc.minIntervalSeconds = getIntFieldOrDefault(c, L"minIntervalSeconds", cfg.defaultMinIntervalSeconds);
         if (cc.minIntervalSeconds < 0) throw JsonParseError("minIntervalSeconds must be >= 0");

--- a/src/lastexecuterecord/FileUtil.cpp
+++ b/src/lastexecuterecord/FileUtil.cpp
@@ -162,17 +162,21 @@ std::wstring readUtf8FileToWString(const std::wstring& path) {
     std::string bytes;
     bytes.resize(static_cast<size_t>(size.QuadPart));
 
-    DWORD read = 0;
     if (size.QuadPart > 0) {
-        if (!ReadFile(h, &bytes[0], static_cast<DWORD>(bytes.size()), &read, nullptr)) {
-            CloseHandle(h);
-            throw win32Error("ReadFile failed");
+        size_t totalRead = 0;
+        while (totalRead < bytes.size()) {
+            DWORD toRead = static_cast<DWORD>(bytes.size() - totalRead);
+            DWORD bytesRead = 0;
+            if (!ReadFile(h, &bytes[totalRead], toRead, &bytesRead, nullptr)) {
+                CloseHandle(h);
+                throw win32Error("ReadFile failed");
+            }
+            if (bytesRead == 0) {
+                CloseHandle(h);
+                throw std::runtime_error("ReadFile returned fewer bytes than expected");
+            }
+            totalRead += bytesRead;
         }
-        if (read != bytes.size()) {
-            CloseHandle(h);
-            throw std::runtime_error("ReadFile returned fewer bytes than expected");
-        }
-        bytes.resize(read);
     }
     if (!CloseHandle(h)) throw win32Error("CloseHandle(read) failed");
 

--- a/src/lastexecuterecord/FileUtil.cpp
+++ b/src/lastexecuterecord/FileUtil.cpp
@@ -1,5 +1,7 @@
-﻿#include "FileUtil.h"
+#include "FileUtil.h"
 
+#include <cwctype>
+#include <limits>
 #include <stdexcept>
 #include <vector>
 
@@ -31,10 +33,20 @@ bool fileExists(const std::wstring& path) {
     return (a & FILE_ATTRIBUTE_DIRECTORY) == 0;
 }
 
-static bool directoryExists(const std::wstring& path) {
+bool directoryExists(const std::wstring& path) {
     DWORD a = GetFileAttributesW(path.c_str());
     if (a == INVALID_FILE_ATTRIBUTES) return false;
     return (a & FILE_ATTRIBUTE_DIRECTORY) != 0;
+}
+
+bool pathIsAbsolute(const std::wstring& path) {
+    if (path.size() >= 3 &&
+        std::iswalpha(path[0]) &&
+        path[1] == L':' &&
+        (path[2] == L'\\' || path[2] == L'/')) {
+        return true;
+    }
+    return path.size() >= 2 && path[0] == L'\\' && path[1] == L'\\';
 }
 
 void ensureDirectoryExists(const std::wstring& path) {
@@ -59,6 +71,32 @@ std::wstring getModulePath() {
     buf.resize(32768);
     DWORD n = GetModuleFileNameW(nullptr, &buf[0], static_cast<DWORD>(buf.size()));
     if (n == 0 || n >= buf.size()) throw win32Error("GetModuleFileNameW failed");
+    buf.resize(n);
+    return buf;
+}
+
+std::wstring getFullPath(const std::wstring& path) {
+    DWORD needed = GetFullPathNameW(path.c_str(), 0, nullptr, nullptr);
+    if (needed == 0) throw win32Error("GetFullPathNameW failed");
+
+    std::wstring full;
+    full.resize(needed);
+    DWORD n = GetFullPathNameW(path.c_str(), needed, &full[0], nullptr);
+    if (n == 0 || n >= needed) throw win32Error("GetFullPathNameW failed");
+    full.resize(n);
+    return full;
+}
+
+std::wstring getSystemDirectoryPath() {
+    std::wstring buf;
+    buf.resize(MAX_PATH);
+    UINT n = GetSystemDirectoryW(&buf[0], static_cast<UINT>(buf.size()));
+    if (n == 0) throw win32Error("GetSystemDirectoryW failed");
+    if (n >= buf.size()) {
+        buf.resize(static_cast<size_t>(n) + 1);
+        n = GetSystemDirectoryW(&buf[0], static_cast<UINT>(buf.size()));
+        if (n == 0 || n >= buf.size()) throw win32Error("GetSystemDirectoryW failed");
+    }
     buf.resize(n);
     return buf;
 }
@@ -130,9 +168,13 @@ std::wstring readUtf8FileToWString(const std::wstring& path) {
             CloseHandle(h);
             throw win32Error("ReadFile failed");
         }
+        if (read != bytes.size()) {
+            CloseHandle(h);
+            throw std::runtime_error("ReadFile returned fewer bytes than expected");
+        }
         bytes.resize(read);
     }
-    CloseHandle(h);
+    if (!CloseHandle(h)) throw win32Error("CloseHandle(read) failed");
 
     // strip UTF-8 BOM
     if (bytes.size() >= 3 &&
@@ -145,13 +187,25 @@ std::wstring readUtf8FileToWString(const std::wstring& path) {
 }
 
 void writeWStringToUtf8FileAtomic(const std::wstring& path, const std::wstring& content) {
-    std::wstring dir = getDirectoryName(path);
-    std::wstring tmp = path + L".tmp";
-
     std::string bytes = wStringToUtf8(content);
+    if (bytes.size() > (std::numeric_limits<DWORD>::max)()) {
+        throw std::runtime_error("Content too large to write");
+    }
 
-    HANDLE h = CreateFileW(tmp.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, nullptr);
-    if (h == INVALID_HANDLE_VALUE) throw win32Error("CreateFileW(write tmp) failed");
+    std::wstring tmp;
+    HANDLE h = INVALID_HANDLE_VALUE;
+    for (int attempt = 0; attempt < 100; ++attempt) {
+        tmp = path + L"." + std::to_wstring(GetCurrentProcessId()) + L"." +
+            std::to_wstring(GetTickCount64()) + L"." + std::to_wstring(attempt) + L".tmp";
+        h = CreateFileW(tmp.c_str(), GENERIC_WRITE, 0, nullptr, CREATE_NEW,
+            FILE_ATTRIBUTE_NORMAL | FILE_ATTRIBUTE_TEMPORARY, nullptr);
+        if (h != INVALID_HANDLE_VALUE) break;
+        DWORD e = GetLastError();
+        if (e != ERROR_FILE_EXISTS && e != ERROR_ALREADY_EXISTS) {
+            throw win32Error("CreateFileW(write tmp) failed");
+        }
+    }
+    if (h == INVALID_HANDLE_VALUE) throw std::runtime_error("Unable to create unique temporary file");
 
     DWORD written = 0;
     if (!bytes.empty()) {
@@ -161,8 +215,15 @@ void writeWStringToUtf8FileAtomic(const std::wstring& path, const std::wstring& 
             throw win32Error("WriteFile failed");
         }
     }
-    FlushFileBuffers(h);
-    CloseHandle(h);
+    if (!FlushFileBuffers(h)) {
+        CloseHandle(h);
+        DeleteFileW(tmp.c_str());
+        throw win32Error("FlushFileBuffers failed");
+    }
+    if (!CloseHandle(h)) {
+        DeleteFileW(tmp.c_str());
+        throw win32Error("CloseHandle(write tmp) failed");
+    }
 
     if (!MoveFileExW(tmp.c_str(), path.c_str(), MOVEFILE_REPLACE_EXISTING | MOVEFILE_WRITE_THROUGH)) {
         DeleteFileW(tmp.c_str());

--- a/src/lastexecuterecord/FileUtil.h
+++ b/src/lastexecuterecord/FileUtil.h
@@ -9,10 +9,14 @@ std::wstring getModulePath();
 std::wstring changeExtension(const std::wstring& path, const std::wstring& extWithDot);
 std::wstring getDirectoryName(const std::wstring& path);
 std::wstring joinPath(const std::wstring& dir, const std::wstring& leaf);
+std::wstring getFullPath(const std::wstring& path);
+std::wstring getSystemDirectoryPath();
 
 // Win32 helpers
 std::wstring getEnvVar(const wchar_t* name);
 bool fileExists(const std::wstring& path);
+bool directoryExists(const std::wstring& path);
+bool pathIsAbsolute(const std::wstring& path);
 void ensureDirectoryExists(const std::wstring& path);
 
 // UTF-8 file IO (accepts UTF-8 with/without BOM)

--- a/src/lastexecuterecord/InstallerUtil.cpp
+++ b/src/lastexecuterecord/InstallerUtil.cpp
@@ -31,39 +31,52 @@ static bool isInstallerProcess(const std::wstring& processName) {
 }
 
 bool isInstallerRunning() {
+    return checkInstallerRunning().status == InstallerCheckStatus::Running;
+}
+
+InstallerCheckResult checkInstallerRunning() {
     // Create a snapshot of all running processes
     HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
     if (hSnapshot == INVALID_HANDLE_VALUE) {
-        return false; // Can't check, assume not running
+        return InstallerCheckResult{ InstallerCheckStatus::CheckFailed, GetLastError() };
     }
 
     PROCESSENTRY32W pe32{};
     pe32.dwSize = sizeof(PROCESSENTRY32W);
 
-    bool installerFound = false;
+    InstallerCheckResult result{ InstallerCheckStatus::NotRunning, 0 };
 
     // Get the first process
     if (Process32FirstW(hSnapshot, &pe32)) {
         do {
             std::wstring exeFile(pe32.szExeFile);
             if (isInstallerProcess(exeFile)) {
-                installerFound = true;
+                result.status = InstallerCheckStatus::Running;
                 break;
             }
         } while (Process32NextW(hSnapshot, &pe32));
     }
+    else {
+        result.status = InstallerCheckStatus::CheckFailed;
+        result.errorCode = GetLastError();
+    }
 
     CloseHandle(hSnapshot);
-    return installerFound;
+    return result;
 }
 
 bool waitForInstallerToFinish(std::int64_t waitSeconds, std::int64_t maxRetries) {
     if (maxRetries <= 0) {
         maxRetries = 1; // At least check once
     }
+    if (waitSeconds <= 0) {
+        waitSeconds = 1; // Avoid a tight retry loop
+    }
 
     for (std::int64_t attempt = 0; attempt < maxRetries; attempt++) {
-        if (!isInstallerRunning()) {
+        InstallerCheckResult check = checkInstallerRunning();
+        if (check.status == InstallerCheckStatus::NotRunning ||
+            check.status == InstallerCheckStatus::CheckFailed) {
             return true; // Installer finished or not running
         }
 

--- a/src/lastexecuterecord/InstallerUtil.h
+++ b/src/lastexecuterecord/InstallerUtil.h
@@ -4,6 +4,20 @@
 
 namespace ler {
 
+enum class InstallerCheckStatus {
+    NotRunning,
+    Running,
+    CheckFailed,
+};
+
+struct InstallerCheckResult {
+    InstallerCheckStatus status = InstallerCheckStatus::CheckFailed;
+    std::uint32_t errorCode = 0;
+};
+
+// Check installer process status and report snapshot/enumeration failures.
+InstallerCheckResult checkInstallerRunning();
+
 // Check if Windows Installer (msiexec.exe) or other installer processes are running
 bool isInstallerRunning();
 

--- a/src/lastexecuterecord/Json.cpp
+++ b/src/lastexecuterecord/Json.cpp
@@ -6,10 +6,17 @@
 
 namespace ler {
 
+static constexpr int kMaxJsonDepth = 256;
+
 static std::string narrowContext(const wchar_t* wctx) {
     if (!wctx) return "";
     std::wstring ws(wctx);
-    return std::string(ws.begin(), ws.end());
+    std::string out;
+    out.reserve(ws.size());
+    for (wchar_t c : ws) {
+        out.push_back(c >= 0 && c <= 0x7F ? static_cast<char>(c) : '?');
+    }
+    return out;
 }
 
 const JsonValue* JsonValue::tryGet(const std::wstring& key) const {
@@ -38,11 +45,7 @@ const std::wstring& JsonValue::asString(const wchar_t* ctx) const {
 std::int64_t JsonValue::asInt(const wchar_t* ctx) const {
     if (type == Type::Int) return i;
     if (type == Type::Double) {
-        if (d < static_cast<double>(std::numeric_limits<std::int64_t>::min()) ||
-            d > static_cast<double>(std::numeric_limits<std::int64_t>::max())) {
-            throw JsonParseError("Number out of int64 range at " + narrowContext(ctx));
-        }
-        return static_cast<std::int64_t>(d);
+        throw JsonParseError("Expected integer at " + narrowContext(ctx));
     }
     throw JsonParseError("Expected number at " + narrowContext(ctx));
 }
@@ -60,8 +63,16 @@ struct Parser {
 
     explicit Parser(const std::wstring& text) : t(text) {}
 
+    static bool isJsonWhitespace(wchar_t c) {
+        return c == L' ' || c == L'\t' || c == L'\r' || c == L'\n';
+    }
+
+    static bool isJsonDigit(wchar_t c) {
+        return c >= L'0' && c <= L'9';
+    }
+
     void skipWs() {
-        while (p < t.size() && iswspace(t[p])) p++;
+        while (p < t.size() && isJsonWhitespace(t[p])) p++;
     }
 
     wchar_t peek() {
@@ -120,7 +131,7 @@ struct Parser {
         std::wstring out;
         while (p < t.size()) {
             wchar_t c = t[p++];
-            if (c == L'\"') break;
+            if (c == L'\"') return out;
             if (c == L'\\') {
                 if (p >= t.size()) throw JsonParseError("Invalid escape");
                 wchar_t e = t[p++];
@@ -142,24 +153,24 @@ struct Parser {
                         u = static_cast<uint16_t>((u << 4) | hv);
                     }
                     if (isHighSurrogate(u)) {
-                        // try surrogate pair
-                        size_t save = p;
-                        if (p + 6 <= t.size() && t[p] == L'\\' && t[p + 1] == L'u') {
-                            p += 2;
-                            uint16_t u2 = 0;
-                            for (int k = 0; k < 4; k++) {
-                                int hv = hexVal(t[p++]);
-                                if (hv < 0) throw JsonParseError("Invalid unicode escape");
-                                u2 = static_cast<uint16_t>((u2 << 4) | hv);
-                            }
-                            if (isLowSurrogate(u2)) {
-                                uint32_t cp = 0x10000 + (((u - 0xD800) << 10) | (u2 - 0xDC00));
-                                appendCodepoint(out, cp);
-                                break;
-                            }
+                        if (p + 6 > t.size() || t[p] != L'\\' || t[p + 1] != L'u') {
+                            throw JsonParseError("Invalid unicode surrogate pair");
                         }
-                        p = save;
-                        out.push_back(static_cast<wchar_t>(u));
+                        p += 2;
+                        uint16_t u2 = 0;
+                        for (int k = 0; k < 4; k++) {
+                            int hv = hexVal(t[p++]);
+                            if (hv < 0) throw JsonParseError("Invalid unicode escape");
+                            u2 = static_cast<uint16_t>((u2 << 4) | hv);
+                        }
+                        if (!isLowSurrogate(u2)) {
+                            throw JsonParseError("Invalid unicode surrogate pair");
+                        }
+                        uint32_t cp = 0x10000 + (((u - 0xD800) << 10) | (u2 - 0xDC00));
+                        appendCodepoint(out, cp);
+                    }
+                    else if (isLowSurrogate(u)) {
+                        throw JsonParseError("Invalid unicode surrogate pair");
                     }
                     else {
                         out.push_back(static_cast<wchar_t>(u));
@@ -171,10 +182,13 @@ struct Parser {
                 }
             }
             else {
+                if (c >= 0 && c <= 0x1F) {
+                    throw JsonParseError("Unescaped control character in string");
+                }
                 out.push_back(c);
             }
         }
-        return out;
+        throw JsonParseError("Unterminated string");
     }
 
     JsonValue parseNumber() {
@@ -185,22 +199,22 @@ struct Parser {
             p++;
         }
         else {
-            if (!iswdigit(peek())) throw JsonParseError("Invalid number");
-            while (iswdigit(peek())) p++;
+            if (!isJsonDigit(peek())) throw JsonParseError("Invalid number");
+            while (isJsonDigit(peek())) p++;
         }
         bool isFloat = false;
         if (peek() == L'.') {
             isFloat = true;
             p++;
-            if (!iswdigit(peek())) throw JsonParseError("Invalid number");
-            while (iswdigit(peek())) p++;
+            if (!isJsonDigit(peek())) throw JsonParseError("Invalid number");
+            while (isJsonDigit(peek())) p++;
         }
         if (peek() == L'e' || peek() == L'E') {
             isFloat = true;
             p++;
             if (peek() == L'+' || peek() == L'-') p++;
-            if (!iswdigit(peek())) throw JsonParseError("Invalid number");
-            while (iswdigit(peek())) p++;
+            if (!isJsonDigit(peek())) throw JsonParseError("Invalid number");
+            while (isJsonDigit(peek())) p++;
         }
 
         std::wstring num = t.substr(start, p - start);
@@ -212,8 +226,11 @@ struct Parser {
                 if (idx != num.size()) throw JsonParseError("Invalid number");
                 return JsonValue::makeInt(static_cast<std::int64_t>(v));
             }
-            catch (...) {
-                // fallback to double
+            catch (const std::out_of_range&) {
+                throw JsonParseError("Number out of int64 range");
+            }
+            catch (const std::invalid_argument&) {
+                throw JsonParseError("Invalid number");
             }
         }
 
@@ -223,18 +240,22 @@ struct Parser {
             if (idx != num.size()) throw JsonParseError("Invalid number");
             return JsonValue::makeDouble(dv);
         }
-        catch (...) {
+        catch (const std::out_of_range&) {
+            throw JsonParseError("Number out of double range");
+        }
+        catch (const std::invalid_argument&) {
             throw JsonParseError("Invalid number");
         }
     }
 
-    JsonValue parseArray() {
+    JsonValue parseArray(int depth) {
+        if (depth > kMaxJsonDepth) throw JsonParseError("JSON nesting too deep");
         expect(L'[', "Expected [");
         std::vector<JsonValue> arr;
         skipWs();
         if (consume(L']')) return JsonValue::makeArray(std::move(arr));
         while (true) {
-            arr.push_back(parseValue());
+            arr.push_back(parseValue(depth + 1));
             skipWs();
             if (consume(L',')) continue;
             expect(L']', "Expected ]");
@@ -243,7 +264,8 @@ struct Parser {
         return JsonValue::makeArray(std::move(arr));
     }
 
-    JsonValue parseObject() {
+    JsonValue parseObject(int depth) {
+        if (depth > kMaxJsonDepth) throw JsonParseError("JSON nesting too deep");
         expect(L'{', "Expected {");
         std::vector<std::pair<std::wstring, JsonValue>> obj;
         skipWs();
@@ -253,7 +275,12 @@ struct Parser {
             std::wstring key = parseString();
             skipWs();
             expect(L':', "Expected :");
-            JsonValue value = parseValue();
+            for (const auto& existing : obj) {
+                if (existing.first == key) {
+                    throw JsonParseError("Duplicate object key");
+                }
+            }
+            JsonValue value = parseValue(depth + 1);
             obj.push_back(std::make_pair(std::move(key), std::move(value)));
             skipWs();
             if (consume(L',')) continue;
@@ -263,13 +290,14 @@ struct Parser {
         return JsonValue::makeObject(std::move(obj));
     }
 
-    JsonValue parseValue() {
+    JsonValue parseValue(int depth = 0) {
+        if (depth > kMaxJsonDepth) throw JsonParseError("JSON nesting too deep");
         skipWs();
         wchar_t c = peek();
         if (c == L'\"') return JsonValue::makeString(parseString());
-        if (c == L'{') return parseObject();
-        if (c == L'[') return parseArray();
-        if (c == L'-' || iswdigit(c)) return parseNumber();
+        if (c == L'{') return parseObject(depth + 1);
+        if (c == L'[') return parseArray(depth + 1);
+        if (c == L'-' || isJsonDigit(c)) return parseNumber();
         if (matchLiteral(L"true")) return JsonValue::makeBool(true);
         if (matchLiteral(L"false")) return JsonValue::makeBool(false);
         if (matchLiteral(L"null")) return JsonValue::makeNull();

--- a/src/lastexecuterecord/NetworkUtil.cpp
+++ b/src/lastexecuterecord/NetworkUtil.cpp
@@ -1,171 +1,123 @@
-﻿// NetworkUtil.cpp
+// NetworkUtil.cpp
 #include "NetworkUtil.h"
 
 #include <Windows.h>
-#include <netlistmgr.h>
 #include <combaseapi.h>
+#include <netlistmgr.h>
 #include <wrl/client.h>
 
 using Microsoft::WRL::ComPtr;
 
 namespace ler {
+namespace {
 
-bool hasInternetConnection() {
-    // Initialize COM for this thread if not already initialized
-    HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-    bool comInitialized = SUCCEEDED(hrInit);
-    
-    bool hasConnection = false;
-    {
-        // Create NetworkListManager instance
-        ComPtr<INetworkListManager> pNetworkListManager;
-        HRESULT hr = CoCreateInstance(
-            CLSID_NetworkListManager,
-            nullptr,
-            CLSCTX_ALL,
-            IID_INetworkListManager,
-            reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
-        );
-
-        if (SUCCEEDED(hr)) {
-            NLM_CONNECTIVITY connectivity;
-            hr = pNetworkListManager->GetConnectivity(&connectivity);
-            if (SUCCEEDED(hr)) {
-                // Check if we have internet connectivity
-                hasConnection = (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
-                               (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
-            }
-        }
-    } // ComPtr released here, before CoUninitialize
-    
-    if (comInitialized) {
-        CoUninitialize();
-    }
-    
-    return hasConnection;
-}
-
-bool isConnectionMetered() {
-    // Initialize COM for this thread if not already initialized
-    HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-    bool comInitialized = SUCCEEDED(hrInit);
-    
+struct NetworkProbe {
+    bool statusKnown = false;
+    bool hasInternet = false;
     bool isMetered = false;
+    HRESULT error = S_OK;
+};
+
+static bool hasInternetConnectivity(NLM_CONNECTIVITY connectivity) {
+    return (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
+        (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
+}
+
+static NetworkProbe probeNetwork(bool requireCost) {
+    HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    bool comInitialized = SUCCEEDED(hrInit);
+
+    NetworkProbe probe;
     {
-        // Create NetworkListManager instance
-        ComPtr<INetworkListManager> pNetworkListManager;
+        ComPtr<INetworkListManager> networkListManager;
         HRESULT hr = CoCreateInstance(
             CLSID_NetworkListManager,
             nullptr,
             CLSCTX_ALL,
             IID_INetworkListManager,
-            reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
-        );
+            reinterpret_cast<void**>(networkListManager.GetAddressOf()));
 
-        if (SUCCEEDED(hr)) {
-            // Use INetworkCostManager to check cost
-            ComPtr<INetworkCostManager> pCostManager;
-            hr = pNetworkListManager->QueryInterface(IID_INetworkCostManager,
-                                                     reinterpret_cast<void**>(pCostManager.GetAddressOf()));
-
-            if (SUCCEEDED(hr)) {
-                DWORD costFlags = 0;
-                hr = pCostManager->GetCost(&costFlags, nullptr);
-
-                if (SUCCEEDED(hr)) {
-                    // Check if connection is NOT unrestricted (meaning it's metered)
-                    isMetered = (costFlags != NLM_CONNECTION_COST_UNRESTRICTED);
-                }
-            }
+        if (FAILED(hr)) {
+            probe.error = hr;
         }
-    } // ComPtr released here, before CoUninitialize
+        else {
+            NLM_CONNECTIVITY connectivity{};
+            hr = networkListManager->GetConnectivity(&connectivity);
+            if (FAILED(hr)) {
+                probe.error = hr;
+            }
+            else {
+                probe.hasInternet = hasInternetConnectivity(connectivity);
+                probe.statusKnown = true;
 
-    if (comInitialized) {
-        CoUninitialize();
-    }
-
-    return isMetered;
-}
-
-bool shouldExecuteBasedOnNetwork(NetworkOption option) {
-    switch (option) {
-        case NetworkOption::AlwaysExecute:
-            // Always execute regardless of network status
-            return true;
-            
-        case NetworkOption::ExecuteOnMetered:
-            // Execute if any internet connection exists (metered or not)
-            return hasInternetConnection();
-            
-        case NetworkOption::ExecuteWhenConnected: {
-            // Execute only if connected and NOT metered
-            // Note: This optimizes by combining connectivity and metered checks in a single
-            // COM initialization, avoiding redundant API calls compared to calling
-            // hasInternetConnection() + isConnectionMetered() separately.
-            
-            // Initialize COM for this thread if not already initialized
-            HRESULT hrInit = CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
-            bool comInitialized = SUCCEEDED(hrInit);
-            
-            bool shouldExecute = false;
-            {
-                // Create NetworkListManager instance
-                ComPtr<INetworkListManager> pNetworkListManager;
-                HRESULT hr = CoCreateInstance(
-                    CLSID_NetworkListManager,
-                    nullptr,
-                    CLSCTX_ALL,
-                    IID_INetworkListManager,
-                    reinterpret_cast<void**>(pNetworkListManager.GetAddressOf())
-                );
-
-                if (SUCCEEDED(hr)) {
-                    // Check connectivity first
-                    NLM_CONNECTIVITY connectivity;
-                    hr = pNetworkListManager->GetConnectivity(&connectivity);
-                    if (SUCCEEDED(hr)) {
-                        bool hasConnection = (connectivity & NLM_CONNECTIVITY_IPV4_INTERNET) ||
-                                            (connectivity & NLM_CONNECTIVITY_IPV6_INTERNET);
-
-                        if (hasConnection) {
-                            // Connected - now check if metered using INetworkCostManager
-                            ComPtr<INetworkCostManager> pCostManager;
-                            hr = pNetworkListManager->QueryInterface(IID_INetworkCostManager,
-                                                                     reinterpret_cast<void**>(pCostManager.GetAddressOf()));
-
-                            if (SUCCEEDED(hr)) {
-                                DWORD costFlags = 0;
-                                hr = pCostManager->GetCost(&costFlags, nullptr);
-
-                                if (SUCCEEDED(hr)) {
-                                    // Execute only if NOT metered
-                                    shouldExecute = (costFlags == NLM_CONNECTION_COST_UNRESTRICTED);
-                                }
-                                else {
-                                    // If cost check fails, assume unrestricted for safety
-                                    shouldExecute = true;
-                                }
-                            }
-                            else {
-                                // If cost manager not available, assume unrestricted
-                                shouldExecute = true;
-                            }
+                if (probe.hasInternet && requireCost) {
+                    ComPtr<INetworkCostManager> costManager;
+                    hr = networkListManager->QueryInterface(
+                        IID_INetworkCostManager,
+                        reinterpret_cast<void**>(costManager.GetAddressOf()));
+                    if (FAILED(hr)) {
+                        probe.statusKnown = false;
+                        probe.error = hr;
+                    }
+                    else {
+                        DWORD costFlags = 0;
+                        hr = costManager->GetCost(&costFlags, nullptr);
+                        if (FAILED(hr)) {
+                            probe.statusKnown = false;
+                            probe.error = hr;
+                        }
+                        else {
+                            probe.isMetered = (costFlags != NLM_CONNECTION_COST_UNRESTRICTED);
                         }
                     }
                 }
-            } // ComPtr released here, before CoUninitialize
-
-            if (comInitialized) {
-                CoUninitialize();
             }
-
-            return shouldExecute;
         }
-            
-        default:
-            // Unknown option, default to always execute
-            return true;
     }
+
+    if (comInitialized) {
+        CoUninitialize();
+    }
+
+    return probe;
+}
+
+} // namespace
+
+bool hasInternetConnection() {
+    NetworkProbe probe = probeNetwork(false);
+    return probe.statusKnown && probe.hasInternet;
+}
+
+bool isConnectionMetered() {
+    NetworkProbe probe = probeNetwork(true);
+    return probe.statusKnown && probe.isMetered;
+}
+
+NetworkDecision evaluateNetworkOption(NetworkOption option) {
+    if (option == NetworkOption::AlwaysExecute) {
+        return NetworkDecision{ true, true, 0 };
+    }
+
+    if (option != NetworkOption::ExecuteOnMetered &&
+        option != NetworkOption::ExecuteWhenConnected) {
+        return NetworkDecision{ false, false, ERROR_INVALID_PARAMETER };
+    }
+
+    NetworkProbe probe = probeNetwork(option == NetworkOption::ExecuteWhenConnected);
+    if (!probe.statusKnown) {
+        return NetworkDecision{ false, false, static_cast<std::uint32_t>(probe.error) };
+    }
+
+    if (option == NetworkOption::ExecuteOnMetered) {
+        return NetworkDecision{ probe.hasInternet, true, 0 };
+    }
+
+    return NetworkDecision{ probe.hasInternet && !probe.isMetered, true, 0 };
+}
+
+bool shouldExecuteBasedOnNetwork(NetworkOption option) {
+    return evaluateNetworkOption(option).shouldExecute;
 }
 
 } // namespace ler

--- a/src/lastexecuterecord/NetworkUtil.h
+++ b/src/lastexecuterecord/NetworkUtil.h
@@ -12,6 +12,12 @@ enum class NetworkOption : std::int32_t {
     AlwaysExecute = 2             // Always execute (ignore network status)
 };
 
+struct NetworkDecision {
+    bool shouldExecute = false;
+    bool statusKnown = false;
+    std::uint32_t errorCode = 0;
+};
+
 // Check if the system has internet connectivity
 // Returns true if connected to internet (any type)
 bool hasInternetConnection();
@@ -24,5 +30,8 @@ bool isConnectionMetered();
 // Check if execution should proceed based on network option
 // Returns true if execution should continue, false if it should be skipped
 bool shouldExecuteBasedOnNetwork(NetworkOption option);
+
+// Check if execution should proceed and report whether network status was known.
+NetworkDecision evaluateNetworkOption(NetworkOption option);
 
 } // namespace ler

--- a/src/lastexecuterecord/lastexecuterecord.vcxproj
+++ b/src/lastexecuterecord/lastexecuterecord.vcxproj
@@ -84,6 +84,14 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <TreatWarningAsError>true</TreatWarningAsError>
+    </ClCompile>
+  </ItemDefinitionGroup>
   <PropertyGroup>
     <LinkIncremental>true</LinkIncremental>
   </PropertyGroup>
@@ -91,6 +99,7 @@
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <Optimization>MinSpace</Optimization>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -103,17 +112,20 @@
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <Optimization>MinSpace</Optimization>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
+      <RuntimeLibrary>MultiThreadedDebugDLL</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <Optimization>MinSpace</Optimization>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">

--- a/src/lastexecuterecord/main.cpp
+++ b/src/lastexecuterecord/main.cpp
@@ -15,7 +15,6 @@
 #include "TimeUtil.h"
 
 static constexpr DWORD kLockRetryIntervalMs = 1000;  // 1 second between file-lock retries
-static constexpr DWORD kMaxSleepMs = (std::numeric_limits<DWORD>::max)(); // cap for Sleep()
 static constexpr std::int64_t kDefaultLockTimeoutSeconds = 300;
 
 static bool tryParseNonNegativeInt64(const std::wstring& text, std::int64_t& value) {
@@ -198,52 +197,25 @@ int wmain(int argc, wchar_t* argv[]) {
 				continue;
 			}
 
-			// Check for running installer processes
-			if (ler::isInstallerRunning()) {
+			ler::InstallerCheckResult installerCheck = ler::checkInstallerRunning();
+			if (installerCheck.status == ler::InstallerCheckStatus::CheckFailed) {
+				if (verbose) {
+					std::wcout << L"[warn] " << c.name << L": installer check failed (error="
+						<< installerCheck.errorCode << L"); proceeding\n";
+				}
+			}
+			else if (installerCheck.status == ler::InstallerCheckStatus::Running) {
 				if (c.installerWaitBehavior == ler::InstallerWaitBehavior::Skip) {
 					std::wcout << L"[skip] " << c.name << L": installer process is running (configured to skip)\n";
 					continue;
 				}
 				else {
-					// Wait for installer to finish, printing a status line on each attempt.
-					// Treat installerMaxRetries <= 0 as 1 (guarantee at least one wait attempt).
 					std::int64_t maxRetries = c.installerMaxRetries > 0 ? c.installerMaxRetries : 1;
+					std::int64_t waitSeconds = c.installerWaitSeconds > 0 ? c.installerWaitSeconds : 1;
+					std::wcout << L"[wait] " << c.name << L": installer process detected, waiting "
+						<< L"(" << maxRetries << L" checks, " << waitSeconds << L"s interval)...\n";
 
-					// Compute the actual wait interval in seconds, matching the Sleep() duration.
-					const std::int64_t maxSleepSeconds = static_cast<std::int64_t>(kMaxSleepMs) / 1000;
-					std::int64_t effectiveWaitSeconds;
-					if (c.installerWaitSeconds <= 0) {
-						effectiveWaitSeconds = 1; // Ensure at least a minimal wait
-					}
-					else if (c.installerWaitSeconds > maxSleepSeconds) {
-						effectiveWaitSeconds = maxSleepSeconds; // Cap to Sleep() limit
-					}
-					else {
-						effectiveWaitSeconds = c.installerWaitSeconds;
-					}
-					DWORD sleepMs = static_cast<DWORD>(effectiveWaitSeconds * 1000);
-
-					bool installerFinished = false;
-					for (std::int64_t attempt = 0; attempt < maxRetries; ++attempt) {
-						// Check immediately whether the installer has finished.
-						if (!ler::isInstallerRunning()) {
-							installerFinished = true;
-							break;
-						}
-
-						// Only sleep if we have another attempt remaining.
-						if (attempt + 1 < maxRetries) {
-							std::wcout << L"[wait] " << c.name << L": installer process detected, waiting "
-								<< L"(attempt " << (attempt + 1) << L"/" << maxRetries
-								<< L", " << effectiveWaitSeconds << L"s interval";
-							if (effectiveWaitSeconds != c.installerWaitSeconds) {
-								std::wcout << L" (configured " << c.installerWaitSeconds << L"s)";
-							}
-							std::wcout << L")...\n";
-							Sleep(sleepMs);
-						}
-					}
-					if (!installerFinished) {
+					if (!ler::waitForInstallerToFinish(waitSeconds, maxRetries)) {
 						std::wcout << L"[skip] " << c.name << L": installer still running after waiting\n";
 						continue;
 					}

--- a/src/lastexecuterecord/main.cpp
+++ b/src/lastexecuterecord/main.cpp
@@ -135,8 +135,13 @@ int wmain(int argc, wchar_t* argv[]) {
 
 		ler::AppConfig cfg = ler::loadAndValidateConfig(configPath);
 
-		// Check network status early if networkOption requires it
-		if (!ler::shouldExecuteBasedOnNetwork(cfg.networkOption)) {
+		// Check network status early if networkOption requires it.
+		ler::NetworkDecision networkDecision = ler::evaluateNetworkOption(cfg.networkOption);
+		if (!networkDecision.statusKnown && verbose) {
+			std::wcout << L"[warn] Network status check failed (error="
+				<< networkDecision.errorCode << L"); skipping network-gated commands\n";
+		}
+		if (!networkDecision.shouldExecute) {
 			if (verbose) {
 				std::wcout << L"[skip] Skipping all commands due to network status (networkOption="
 					<< static_cast<int>(cfg.networkOption) << L")\n";

--- a/src/lastexecuterecord/main.cpp
+++ b/src/lastexecuterecord/main.cpp
@@ -1,4 +1,6 @@
 #include <Windows.h>
+#include <cerrno>
+#include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <string>
@@ -14,6 +16,21 @@
 
 static constexpr DWORD kLockRetryIntervalMs = 1000;  // 1 second between file-lock retries
 static constexpr DWORD kMaxSleepMs = (std::numeric_limits<DWORD>::max)(); // cap for Sleep()
+static constexpr std::int64_t kDefaultLockTimeoutSeconds = 300;
+
+static bool tryParseNonNegativeInt64(const std::wstring& text, std::int64_t& value) {
+	if (text.empty()) return false;
+
+	wchar_t* end = nullptr;
+	errno = 0;
+	long long parsed = std::wcstoll(text.c_str(), &end, 10);
+	if (errno == ERANGE || end == text.c_str() || *end != L'\0' || parsed < 0) {
+		return false;
+	}
+
+	value = static_cast<std::int64_t>(parsed);
+	return true;
+}
 
 static void printUsage(const wchar_t* exeName) {
 	std::wcout
@@ -24,13 +41,16 @@ static void printUsage(const wchar_t* exeName) {
 		<< L"Options:\n"
 		<< L"  --config <path>  Path to config JSON (default: %USERPROFILE%\\.lastexecrecord\\config.json)\n"
 		<< L"  --dry-run        Do not execute; only show decisions\n"
-		<< L"  --verbose        Print skip reasons and detailed output\n";
+		<< L"  --verbose        Print skip reasons and detailed output\n"
+		<< L"  --lock-timeout <seconds>\n"
+		<< L"                   Max time to wait for the config lock (default: 300)\n";
 }
 
 int wmain(int argc, wchar_t* argv[]) {
 	bool dryRun = false;
 	bool verbose = false;
 	std::wstring configPath = ler::defaultConfigPath();
+	std::int64_t lockTimeoutSeconds = kDefaultLockTimeoutSeconds;
 
 	// Parse arguments (skip if argc <= 1, i.e., no arguments provided)
 	if (argc > 1) {
@@ -56,6 +76,17 @@ int wmain(int argc, wchar_t* argv[]) {
 				configPath = argv[++i];
 				continue;
 			}
+			if (a == L"--lock-timeout") {
+				if (i + 1 >= argc) {
+					std::wcerr << L"--lock-timeout requires seconds\n";
+					return 2;
+				}
+				if (!tryParseNonNegativeInt64(argv[++i], lockTimeoutSeconds)) {
+					std::wcerr << L"--lock-timeout must be a non-negative integer\n";
+					return 2;
+				}
+				continue;
+			}
 
 			std::wcerr << L"Unknown argument: " << a << L"\n";
 			printUsage(argv[0]);
@@ -64,20 +95,44 @@ int wmain(int argc, wchar_t* argv[]) {
 	}
 
 	try {
-		// Auto-generate a sample config once (do not overwrite) to improve onboarding.
-		ler::ensureSampleConfigExists(configPath);
+		configPath = ler::getFullPath(configPath);
+		std::wstring configDir = ler::getDirectoryName(configPath);
+		if (configDir.empty()) {
+			throw std::runtime_error("Config path has no directory component");
+		}
+		ler::ensureDirectoryExists(configDir);
 
 		// Prevent concurrent runs against the same config file.
-		// Retry until the lock is acquired, printing a waiting message while blocked.
+		// Retry until the lock is acquired or the bounded wait expires.
 		std::wstring lockPath = configPath + L".lock";
 		ler::FileLock lock = ler::tryAcquireLockFile(lockPath);
 		if (lock.h == INVALID_HANDLE_VALUE) {
 			std::wcout << L"[wait] Waiting for file lock: " << lockPath << L"\n";
+			const std::int64_t maxTimeoutMs =
+				static_cast<std::int64_t>((std::numeric_limits<DWORD>::max)());
+			std::int64_t timeoutMs = lockTimeoutSeconds > maxTimeoutMs / 1000
+				? maxTimeoutMs
+				: lockTimeoutSeconds * 1000;
+			std::int64_t waitedMs = 0;
 			do {
-				Sleep(kLockRetryIntervalMs);
+				if (waitedMs >= timeoutMs) {
+					std::wcerr << L"Fatal: timed out waiting for file lock after "
+						<< lockTimeoutSeconds << L" seconds\n";
+					return 2;
+				}
+				DWORD sleepMs = kLockRetryIntervalMs;
+				std::int64_t remainingMs = timeoutMs - waitedMs;
+				if (remainingMs < static_cast<std::int64_t>(sleepMs)) {
+					sleepMs = static_cast<DWORD>(remainingMs);
+				}
+				Sleep(sleepMs);
+				waitedMs += sleepMs;
 				lock = ler::tryAcquireLockFile(lockPath);
 			} while (lock.h == INVALID_HANDLE_VALUE);
 		}
+
+		// Auto-generate a sample config once while holding the same config lock.
+		ler::ensureSampleConfigExists(configPath);
 
 		ler::AppConfig cfg = ler::loadAndValidateConfig(configPath);
 

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,6 +3,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg",
-    "baseline": "c3867e714dd3a51c272826eea77267876517ed99"
+    "baseline": "af752f21c9d79ba3df9cb0250ce2233933f58486"
   }
 }


### PR DESCRIPTION
This implements the design audit hardening plan from issue #29 and addresses the highest-risk gaps found while reviewing process execution, config parsing, file updates, build settings, and release automation. The focus is to make command execution safer and failure modes more explicit without adding runtime dependencies.

## Summary

- Hardened command execution by fixing empty-argument quoting, adding RAII handle cleanup, and surfacing process wait, termination, and exit-code failures.
- Tightened config parsing and validation with strict JSON behavior, integer-only config fields, absolute existing `exe` paths, and absolute existing `workingDirectory` paths.
- Improved file safety by normalizing config lock paths, creating sample configs under lock, adding `--lock-timeout`, and replacing fixed `.tmp` writes with unique same-directory atomic temp files.
- Clarified policy behavior for environment checks: network-gated modes fail closed when network status cannot be verified, while installer-check failures warn in verbose mode and proceed to avoid blocking on unverifiable installer state.
- Hardened MSBuild, CI, release workflows, CodeQL, Dependabot, and user-facing documentation.

## Review notes

- The absolute-path requirement for `exe` and `workingDirectory` is an intentional security hardening change and may require existing configs to be updated.
- Network failures now skip execution for `networkOption` values `0` and `1`; `networkOption` value `2` still always executes.
- Solution-level MSBuild was observed to hang locally, so CI now builds project files explicitly instead of the solution.

## Validation

- Debug x64 app project build succeeded.
- Debug x64 MSTest project build succeeded.
- MSTest passed: 89/89.
- Release x64 app project build succeeded.
- `git diff --check` passed.

Closes #29
Refs #28