### PR TITLE
update dependencies: refresh GitHub Actions and vcpkg baselines

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -35,7 +35,7 @@ jobs:
       pull-requests: read
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
@@ -50,12 +50,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Build (Debug x64)
         run: |
@@ -102,7 +102,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: mstest-results
           path: TestResults/**/*.trx

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,12 +28,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Setup MSBuild
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
 
       - name: Determine version
         shell: pwsh
@@ -79,7 +79,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-mstest-results
           path: TestResults/**/*.trx
@@ -155,7 +155,7 @@ jobs:
           $checksums | Set-Content -Path (Join-Path $dist 'SHA256SUMS.txt') -Encoding ascii
 
       - name: Upload release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: release-dist
           path: dist/*
@@ -170,12 +170,12 @@ jobs:
 
     steps:
       - name: Download release artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-dist
           path: dist
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: dist/*

--- a/src/vcpkg-configuration.json
+++ b/src/vcpkg-configuration.json
@@ -2,6 +2,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg",
-    "baseline": "af752f21c9d79ba3df9cb0250ce2233933f58486"
+    "baseline": "c3867e714dd3a51c272826eea77267876517ed99"
   }
 }

--- a/src/vcpkg.json
+++ b/src/vcpkg.json
@@ -2,5 +2,5 @@
   "name": "lastexecrecord",
   "version-string": "0.0.0",
   "dependencies": [],
-  "builtin-baseline": "af752f21c9d79ba3df9cb0250ce2233933f58486"
+  "builtin-baseline": "c3867e714dd3a51c272826eea77267876517ed99"
 }

--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -3,6 +3,6 @@
   "default-registry": {
     "kind": "git",
     "repository": "https://github.com/microsoft/vcpkg",
-    "baseline": "af752f21c9d79ba3df9cb0250ce2233933f58486"
+    "baseline": "c3867e714dd3a51c272826eea77267876517ed99"
   }
 }


### PR DESCRIPTION
Resolves #39.

This combines the dependency updates from closed Dependabot PRs #31, #32, #33, #34, #35, #36, #37, and #38 because those PRs cannot be reopened after being closed.

Included updates:
- actions/checkout v4 -> v6
- actions/upload-artifact v4 -> v7
- actions/download-artifact v4 -> v8
- microsoft/setup-msbuild v2 -> v3
- softprops/action-gh-release v2 -> v3
- vcpkg baseline af752f21c9d79ba3df9cb0250ce2233933f58486 -> c3867e714dd3a51c272826eea77267876517ed99

Review status from the closed Dependabot PRs:
- No pull request review comments were present on #31, #32, #33, #34, #35, #36, #37, or #38.
- The only PR comments after closing were Dependabot close notifications.